### PR TITLE
docs: rename meta tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ tools = toolset.get_tools("hris_*")
 meta_tools = tools.meta_tools()
 
 # Search for relevant tools using natural language
-filter_tool = meta_tools.get_tool("meta_filter_relevant_tools")
+filter_tool = meta_tools.get_tool("meta_search_tools")
 results = filter_tool.call(query="manage employees", limit=5)
 
 # Execute discovered tools dynamically


### PR DESCRIPTION
related to https://github.com/StackOneHQ/stackone-ai-python/pull/19    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Updated README examples to reflect a meta tool rename. Use meta_search_tools instead of meta_filter_relevant_tools.

<!-- End of auto-generated description by cubic. -->

