### PR TITLE
fix: remove async method

### DIFF
--- a/stackone_ai/models.py
+++ b/stackone_ai/models.py
@@ -1,12 +1,10 @@
 # TODO: Remove when Python 3.9 support is dropped
 from __future__ import annotations
 
-import asyncio
 import base64
 import json
 from collections.abc import Sequence
 from enum import Enum
-from functools import partial
 from typing import Annotated, Any, cast
 from urllib.parse import quote
 
@@ -255,36 +253,6 @@ class StackOneTool(BaseModel):
             return self.execute(args[0])
 
         return self.execute(kwargs if kwargs else None)
-
-    async def acall(self, *args: Any, **kwargs: Any) -> JsonDict:
-        """Async version of call method
-
-        Args:
-            *args: If a single argument is provided, it's treated as the full arguments dict/string
-            **kwargs: Keyword arguments to pass to the tool
-
-        Returns:
-            API response as dict
-
-        Raises:
-            StackOneAPIError: If the API request fails
-            ValueError: If the arguments are invalid
-        """
-        # For now, we'll use asyncio to run the sync version
-        # In the future, this should use aiohttp for true async
-
-        # Create a partial function with the arguments
-        if args and kwargs:
-            raise ValueError("Cannot provide both positional and keyword arguments")
-
-        if args:
-            if len(args) > 1:
-                raise ValueError("Only one positional argument is allowed")
-            func = partial(self.execute, args[0])
-        else:
-            func = partial(self.execute, kwargs if kwargs else None)
-
-        return await asyncio.get_event_loop().run_in_executor(None, func)
 
     def to_openai_function(self) -> JsonDict:
         """Convert this tool to OpenAI's function format

--- a/tests/test_tool_calling.py
+++ b/tests/test_tool_calling.py
@@ -116,24 +116,6 @@ class TestToolCalling:
         with pytest.raises(ValueError, match="Only one positional argument is allowed"):
             mock_tool.call({"name": "test"}, {"value": 42})
 
-    @pytest.mark.asyncio
-    @responses.activate
-    async def test_acall_with_kwargs(self, mock_tool):
-        """Test async calling a tool with keyword arguments"""
-        # Mock the API response
-        responses.add(
-            responses.POST,
-            "https://api.example.com/test",
-            json={"success": True, "result": "async_result"},
-            status=200,
-        )
-
-        # Call the tool asynchronously
-        result = await mock_tool.acall(name="test", value=42)
-
-        # Verify the result
-        assert result == {"success": True, "result": "async_result"}
-
     @responses.activate
     def test_call_without_arguments(self, mock_tool):
         """Test calling a tool without any arguments"""


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Removed the acall method that wrapped the sync call in a thread, simplifying the API and avoiding misleading async behavior. Deleted the related async test.

- **Migration**
  - Replace tool.acall(...) with await asyncio.to_thread(tool.call, ...) in async code.
  - Or use loop.run_in_executor(None, lambda: tool.call(...)) on older patterns.
  - If not using async, call tool.call(...) directly.

<!-- End of auto-generated description by cubic. -->

