### PR TITLE
chore: .env_example

### DIFF
--- a/.env_example
+++ b/.env_example
@@ -1,2 +1,0 @@
-STACKONE_API_KEY=your_stackone_api_key
-OPENAI_API_KEY=your_openai_api_key


### PR DESCRIPTION
we dont need it 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed .env_example (with STACKONE_API_KEY and OPENAI_API_KEY placeholders) from the repo. This avoids confusion and keeps environment configuration managed via deployment secrets or local .env files.

<sup>Written for commit 9c13208f6293b22f5e552493eb950fa3cb7b6de0. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

