### PR TITLE
fix(scripts): add uv lock refresh to version update script

### DIFF
--- a/scripts/update_version.py
+++ b/scripts/update_version.py
@@ -11,13 +11,14 @@ Run this script after release-please updates the version in pyproject.toml.
 """
 
 import re
+import subprocess
 from pathlib import Path
 
 import tomli
 
 
 def main() -> None:
-    """Update version in __init__.py to match pyproject.toml."""
+    """Update version in __init__.py to match pyproject.toml and refresh uv.lock."""
     # Read version from pyproject.toml
     pyproject_path = Path("pyproject.toml")
     init_path = Path("stackone_ai/__init__.py")
@@ -35,6 +36,11 @@ def main() -> None:
         print(f"Updated version in {init_path} to {version}")
     else:
         print(f"Version in {init_path} already matches {version}")
+
+    # Update uv.lock to reflect version change in pyproject.toml
+    print("Updating uv.lock...")
+    subprocess.run(["uv", "lock"], check=True)
+    print("uv.lock updated successfully")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Adds `uv lock` execution to the version update script to ensure the lockfile stays in sync after release-please updates pyproject.toml.

## What Changed

- Added `subprocess` import to run shell commands
- Added `uv lock` execution at the end of `main()`
- Updated docstring to reflect the additional responsibility

## Why

Previously, when release-please updated the version in `pyproject.toml`, the `update_version.py` script would only sync the version to `__init__.py`. This left `uv.lock` potentially out of sync with the new version, which could cause inconsistencies. Now the lockfile is automatically refreshed as part of the version update process.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refreshes uv.lock during version bumps by running uv lock in the update_version.py script. Prevents lockfile drift after release-please updates pyproject.toml.

<sup>Written for commit d1060d8a07ed05a7dd54cf3c101f804e79cfcb9f. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

