### PR TITLE
chore: remove vscode

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,0 @@
-{
-  "python.analysis.ignore": ["scripts/**"],
-  "makefile.configureOnOpen": false
-}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Removed the .vscode/settings.json to avoid committing editor-specific settings and reduce repo clutter. This prevents VS Code preferences (Python analysis ignore and Makefile configure-on-open) from overriding contributors’ local setups.

<sup>Written for commit a8761830356f48d0a731caa049661f7c5338acb9. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

