### PR TITLE
docs: remove obsolete migration section from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -358,25 +358,6 @@ For more examples, check out the [examples/](examples/) directory:
 - [CrewAI Integration](examples/crewai_integration.py)
 - [Meta Tools](examples/meta_tools_example.py)
 
-## Migration from `get_tools()` to `fetch_tools()`
-
-If you're upgrading from a previous version that used `get_tools()`, here's how to migrate:
-
-```python
-# Before (deprecated)
-tools = toolset.get_tools("hris_*", account_id="acc-123")
-
-# After
-tools = toolset.fetch_tools(actions=["hris_*"], account_ids=["acc-123"])
-```
-
-Key differences:
-
-- `fetch_tools()` uses keyword arguments for all filtering
-- `account_id` becomes `account_ids` (list)
-- Filter patterns go in the `actions` parameter (list)
-- `fetch_tools()` requires the MCP extra (`pip install 'stackone-ai[mcp]'`)
-
 ## License
 
 Apache 2.0 License


### PR DESCRIPTION
Removes the migration guide for transitioning from `get_tools()` to `fetch_tools()`. This section is no longer relevant since `get_tools()` was completely removed in #42.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the outdated migration section for get_tools() → fetch_tools() from the README. This cleans up the docs and avoids confusion now that get_tools() is fully removed.

<sup>Written for commit 784188c93e4faf9289620b162065df146c891014. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

