### PR TITLE
chore(nix): add basedpyright to development shell

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -84,6 +84,7 @@
               nixfmt-rfc-style
               typos
               typos-lsp
+              basedpyright
             ];
 
             shellHook = ''


### PR DESCRIPTION
add basedpyright for lsp
<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds basedpyright to the Nix devShell for Python type checking in IDEs. Complements existing mypy hooks with fast, real-time feedback.

<sup>Written for commit c24874eb5cacb1a389785e0eddea3a939ded3087. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

