### PR TITLE
feat(security): add gitleaks for secret detection

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,6 +16,20 @@ permissions:
   id-token: write
 
 jobs:
+  gitleaks:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          fetch-depth: 0
+
+      - name: Setup Nix
+        uses: ./.github/actions/setup-nix
+
+      - name: Run Gitleaks
+        run: nix develop --command just gitleaks
+
   typos:
     runs-on: ubuntu-latest
     steps:

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,13 @@
+# Gitleaks configuration
+# https://github.com/gitleaks/gitleaks
+
+[extend]
+useDefault = true
+
+[allowlist]
+description = "Global allowlist"
+paths = [
+    '''\.lock$''',
+    '''\.snap$''',
+    '''uv\.lock$''',
+]

--- a/flake.nix
+++ b/flake.nix
@@ -62,6 +62,13 @@
           pre-commit = {
             check.enable = false; # Skip check in flake (mypy needs Python env)
             settings.hooks = {
+              gitleaks = {
+                enable = true;
+                name = "gitleaks";
+                entry = "${pkgs.gitleaks}/bin/gitleaks protect --staged --config .gitleaks.toml";
+                language = "system";
+                pass_filenames = false;
+              };
               treefmt = {
                 enable = true;
                 package = config.treefmt.build.wrapper;
@@ -85,6 +92,9 @@
               typos
               typos-lsp
               basedpyright
+
+              # security
+              gitleaks
             ];
 
             shellHook = ''

--- a/justfile
+++ b/justfile
@@ -34,6 +34,10 @@ mypy:
 typos:
 	typos --config typos.toml .
 
+# Run gitleaks secret detection
+gitleaks:
+	gitleaks detect --source . --config .gitleaks.toml
+
 # Fix typos
 typos-fix:
 	typos --config typos.toml --write-changes .


### PR DESCRIPTION
## Summary

- Add gitleaks to detect and prevent secrets from being committed

## What Changed

- Add `.gitleaks.toml` configuration with default rules
- Add gitleaks to pre-commit hook via git-hooks.nix
- Add gitleaks job to CI workflow using nix
- Add `just gitleaks` command
- Add gitleaks to nix flake for local development

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add Gitleaks for secret detection in commits and CI. This blocks accidental secret leaks and makes local scans easy.

- **New Features**
  - Pre-commit hook via Nix to prevent committing secrets.
  - CI job runs Gitleaks using Nix.
  - Devshell includes Gitleaks; run “just gitleaks” to scan the repo.
  - .gitleaks.toml with default rules and an allowlist for common lock files.

<sup>Written for commit 74f117602161439267134273f0cfbcd58d1d8fc4. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

