### PR TITLE
refactor(models): remove unused _arun method from LangChain tool

### DIFF
--- a/stackone_ai/models.py
+++ b/stackone_ai/models.py
@@ -437,9 +437,6 @@ class StackOneTool(BaseModel):
             def _run(self, **kwargs: Any) -> Any:
                 return parent_tool.execute(kwargs)
 
-            async def _arun(self, **kwargs: Any) -> Any:
-                return self._run(**kwargs)
-
         return StackOneLangChainTool()
 
     def set_account_id(self, account_id: str | None) -> None:


### PR DESCRIPTION
## Summary
- Remove the unused `_arun` async method from `StackOneLangChainTool`
- The method was just wrapping the sync `_run` without actual async benefits
- LangChain's `BaseTool` provides a default `NotImplementedError` implementation

## Test plan
- [x] All existing tests pass
- [x] Lint checks pass

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the unused `_arun` method from `StackOneLangChainTool`. We now rely on `BaseTool`’s default `NotImplementedError` for async since the tool doesn’t support true async execution.

<sup>Written for commit bc08246270bb1a244415ca25c0d0283dc0c15aa6. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

