### PR TITLE
chore: fix tyos ignore regex

### DIFF
--- a/typos.toml
+++ b/typos.toml
@@ -1,10 +1,10 @@
 [default]
 locale = 'en-us'
 extend-ignore-re = [
-  "(?s)(#|//)\\s*spellchecker:off.*?\\n\\s*(#|//)\\s*spellchecker:on",
-  "(?s)<!--\\s*spellchecker:off.*?\\n\\s*spellchecker:on\\s*-->",
+  "(?s)(#|//)\\s*spellchecker:off[\\s\\S]*?(#|//)\\s*spellchecker:on",
+  "(?s)<!--\\s*spellchecker:off\\s*-->[\\s\\S]*?<!--\\s*spellchecker:on\\s*-->",
   "(?Rm)^.*#\\s*spellchecker:disable-line$",
-  "(?m)^.*<!--\\s*spellchecker:disable-line\\s*-->\\n.*$"
+  "(?m)^.*<!--\\s*spellchecker:disable-line\\s*-->\\n.*$",
 ]
 
 [files]


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Updated typos.toml ignore regex to correctly skip sections wrapped with spellchecker:off/on in code and HTML comments, even across multiple lines. This reduces false positives from typos checks in disabled blocks.

- **Bug Fixes**
  - Use [\s\S]*? to match multiline content and correctly pair <!-- spellchecker:off --> ... <!-- spellchecker:on --> markers.

<sup>Written for commit 0d410c82bbff8a91064f0ad6bf90ba992294c114. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

