### PR TITLE
chore: use clone link mode for uv to prevent breaking cache

### DIFF
--- a/uv.toml
+++ b/uv.toml
@@ -1,0 +1,1 @@
+link-mode = "clone"


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Configured uv to use clone link mode to prevent cache breaks during installs and builds. Adds uv.toml with link-mode = "clone".

<sup>Written for commit b2e6cb71d62ce27e81390b1ae53ec27aa3aee2ee. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

