### PR TITLE
fix(ci): add submodules checkout to coverage job

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -73,6 +73,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          submodules: true
 
       - name: Setup Nix
         uses: ./.github/actions/setup-nix

--- a/flake.nix
+++ b/flake.nix
@@ -108,6 +108,12 @@
             shellHook = ''
               echo "StackOne AI Python SDK development environment"
 
+              # Initialize git submodules if not already done
+              if [ -f .gitmodules ] && [ ! -f vendor/stackone-ai-node/package.json ]; then
+                echo "📦 Initializing git submodules..."
+                git submodule update --init --recursive
+              fi
+
               # Install Python dependencies only if .venv is missing or uv.lock is newer
               if [ ! -d .venv ] || [ uv.lock -nt .venv ]; then
                 echo "📦 Installing Python dependencies..."


### PR DESCRIPTION
## Summary

Fix CI coverage job failure caused by missing git submodule checkout.

## What Changed

- Add `submodules: true` to coverage job checkout step in CI workflow
- Add automatic submodule initialisation in flake.nix shellHook for local development

## Why

The coverage job was failing with:
```
error: Bun could not find a package.json file to install from
```

This occurred because `vendor/stackone-ai-node` submodule was not checked out. The `ci` job had `submodules: true` but the `coverage` job did not.

## Related

Fixes failed run: https://github.com/StackOneHQ/stackone-ai-python/actions/runs/20637603873

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes CI coverage job failures by checking out required git submodules. Also auto-initializes submodules in local development to prevent setup issues.

- **Bug Fixes**
  - Added submodules: true to the coverage job checkout step so vendor/stackone-ai-node is available for tests.
  - Added submodule initialization in flake.nix shellHook when missing.

<sup>Written for commit a91fc084752b1c8f32b310293b703c78b3f6221c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

