### PR TITLE
ci: remove unused API keys from CI workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -40,9 +40,6 @@ jobs:
             sync-extras: "--all-extras"
           - python-version: "3.13"
             sync-extras: "--all-extras"
-    env:
-      STACKONE_API_KEY: ${{ secrets.STACKONE_API_KEY }}
-      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
@@ -67,9 +64,6 @@ jobs:
   coverage:
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/main'
-    env:
-      STACKONE_API_KEY: ${{ secrets.STACKONE_API_KEY }}
-      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1


### PR DESCRIPTION
## Summary
Remove unused API key environment variables from CI workflow.

## Changes
- Removed `STACKONE_API_KEY` and `OPENAI_API_KEY` environment variables from `ci` and `coverage` jobs

## Reason
These environment variables are not actually used in tests:
- `STACKONE_API_KEY`: Only referenced in a skipped integration test (`test_live_feedback_submission`)
- `OPENAI_API_KEY`: Not used in any tests (only in examples)

## Testing
- ✅ Pre-commit hooks passed
- ✅ No tests require these environment variables

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed unused STACKONE_API_KEY and OPENAI_API_KEY from the CI and coverage jobs to reduce secret exposure and simplify the workflow. Tests don’t use these keys (STACKONE only in a skipped integration test; OPENAI only in examples).

<sup>Written for commit 214db5a0c94fa67408898e827c046673489254ce. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

