### PR TITLE
chore: remove gc store

### DIFF
--- a/.github/actions/setup-nix/action.yaml
+++ b/.github/actions/setup-nix/action.yaml
@@ -20,4 +20,3 @@ runs:
         restore-prefixes-first-match: |
           nix-${{ runner.os }}-${{ inputs.python-version }}-
           nix-${{ runner.os }}-
-        gc-max-store-size: 4G


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Removed the gc-max-store-size (4G) setting from the setup-nix GitHub Action to rely on Nix defaults. This avoids forced garbage collection during CI and reduces unexpected build failures.

<sup>Written for commit 936477940bc81df35e4ff3f82596d71de0fb63ee. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

