### PR TITLE
ci: nix dev true

### DIFF
--- a/.github/actions/setup-nix/action.yaml
+++ b/.github/actions/setup-nix/action.yaml
@@ -20,3 +20,7 @@ runs:
         restore-prefixes-first-match: |
           nix-${{ runner.os }}-${{ inputs.python-version }}-
           nix-${{ runner.os }}-
+
+    - name: Verify Nix installation
+      shell: bash
+      run: nix develop --command true


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add a CI step to verify Nix is correctly installed and the dev shell resolves by running `nix develop --command true`. This fails fast if Nix or caches are misconfigured.

<sup>Written for commit 380f6fc9daf7ae575c1bd7dc10d85d9a82f518d0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

