### PR TITLE
docs(readme): improve Nix development environment setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -337,20 +337,27 @@ For more examples, check out the [examples/](examples/) directory:
 
 ### Using Nix (Recommended)
 
-[Nix](https://nixos.org/) with flakes provides a consistent development environment:
+This project includes a Nix flake for reproducible development environments. All development tools are defined in [flake.nix](./flake.nix) and provided via Nix.
+
+#### Installing Nix
 
 ```bash
-# Enter development environment (auto-installs dependencies and git hooks)
-nix develop
+# Install Nix with flakes enabled (if not already installed)
+curl --proto '=https' --tlsv1.2 -sSf -L https://artifacts.nixos.org/experimental-installer | \
+  sh -s -- install
 
-# Or with direnv (recommended for automatic activation)
+# If flakes are not enabled, enable them with:
+mkdir -p ~/.config/nix && echo "experimental-features = nix-command flakes" >> ~/.config/nix/nix.conf
+```
+
+#### Activating the Development Environment
+
+```bash
+# Automatic activation with direnv (recommended)
 direnv allow
 
-# Format code
-nix fmt
-
-# Run checks
-nix flake check
+# Or manual activation
+nix develop
 ```
 
 The Nix development environment includes:


### PR DESCRIPTION
## Summary
- Add Nix installation command using experimental installer
- Add instructions for enabling flakes if not already enabled
- Clarify direnv activation (use existing .envrc)
- Link to flake.nix for reference
- Reorganise useful commands into separate section

## Test plan
- [ ] Verify README renders correctly on GitHub

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Streamlined the README’s Nix setup to make onboarding faster and the dev environment easier to activate. Added an install command (experimental installer), steps to enable flakes, clarified direnv activation, linked to flake.nix, and grouped useful commands.

<sup>Written for commit 05ddd3f58f949b4d4da5527f09870235fad536cc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

