### PR TITLE
chore: basepyright -> ty

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -81,7 +81,7 @@
               ty = {
                 enable = true;
                 name = "ty";
-                entry = "${pkgs.uv}/bin/uv run ty check";
+                entry = "${pkgs.ty}/bin/ty check";
                 files = "^stackone_ai/";
                 language = "system";
                 types = [ "python" ];
@@ -92,9 +92,9 @@
           devShells.default = pkgs.mkShell {
             buildInputs = with pkgs; [
               uv
+              ty
               just
               nixfmt-rfc-style
-              basedpyright
 
               # security
               gitleaks


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Switched Python type checking from BasedPyright to Ty to standardize tooling and simplify execution.

Updated flake.nix to call ${pkgs.ty}/bin/ty check, added ty to devShell inputs, and removed BasedPyright.

<sup>Written for commit 4301733fd52847793a486480f3900c8ece5b696c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

