### PR TITLE
chore(nix): use mkShellNoCC and update flake inputs

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -89,7 +89,7 @@
             };
           };
 
-          devShells.default = pkgs.mkShell {
+          devShells.default = pkgs.mkShellNoCC {
             buildInputs = with pkgs; [
               uv
               ty


### PR DESCRIPTION
## Summary
- Switch from `mkShell` to `mkShellNoCC` for lighter devShell (no C compiler needed)
- Update all flake inputs to latest versions

## Test plan
- Run `nix develop` and verify the shell works correctly

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch to a lighter Nix dev shell by replacing mkShell with mkShellNoCC, reducing dependencies and speeding up shell activation.

<sup>Written for commit c7c56714eedd201023c3961babeb76aa37efdfa8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

