### PR TITLE
ci(nix): use nix profile install instead of nix develop

### DIFF
--- a/.github/actions/setup-nix/action.yaml
+++ b/.github/actions/setup-nix/action.yaml
@@ -1,5 +1,14 @@
 name: "Setup Nix"
-description: "Install Nix and configure Cachix"
+description: "Install Nix and configure cache"
+inputs:
+  tools:
+    description: 'Space-separated list of nixpkgs packages to install (e.g., "uv ty just")'
+    required: false
+    default: "uv ty just"
+  skip-uv-sync:
+    description: "Skip uv sync step (useful for jobs that do not need Python dependencies)"
+    required: false
+    default: "false"
 runs:
   using: "composite"
   steps:
@@ -8,12 +17,34 @@ runs:
       with:
         github_access_token: ${{ github.token }}
 
-    - name: Setup Cachix (numtide)
-      uses: cachix/cachix-action@0fc020193b5a1fa3ac4575aa3a7d3aa6a35435ad # v16
-      with:
-        name: numtide
-        authToken: ""
-
-    - name: Load Nix development environment
+    - name: Install tools from nixpkgs
       shell: bash
-      run: nix develop --command true
+      run: |
+        tools="${{ inputs.tools }}"
+        packages=""
+        for tool in $tools; do
+          packages="$packages nixpkgs#$tool"
+        done
+        nix profile install --inputs-from . $packages
+
+    - name: Initialise git submodules
+      if: inputs.skip-uv-sync != 'true'
+      shell: bash
+      run: |
+        # Only initialise if submodules exist but are not yet checked out
+        if [ -f .gitmodules ] && [ ! -f vendor/stackone-ai-node/package.json ]; then
+          git submodule update --init --recursive
+        fi
+
+    - name: Install Python dependencies
+      if: inputs.skip-uv-sync != 'true'
+      shell: bash
+      run: uv sync --all-extras
+
+    - name: Install MCP mock server dependencies
+      if: inputs.skip-uv-sync != 'true'
+      shell: bash
+      run: |
+        if [ -f vendor/stackone-ai-node/package.json ]; then
+          cd vendor/stackone-ai-node && pnpm install --frozen-lockfile
+        fi

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,20 +26,18 @@ jobs:
 
       - name: Setup Nix
         uses: ./.github/actions/setup-nix
+        with:
+          tools: gitleaks
+          skip-uv-sync: "true"
 
       - name: Run Gitleaks
-        run: nix develop --command just gitleaks
+        run: gitleaks detect --source . --config .gitleaks.toml
 
   ci:
     runs-on: ubuntu-latest
     strategy:
       matrix:
         python-version: ["3.11", "3.13"]
-        include:
-          - python-version: "3.11"
-            sync-extras: "--all-extras"
-          - python-version: "3.13"
-            sync-extras: "--all-extras"
     steps:
       - name: Checkout repository
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
@@ -48,18 +46,17 @@ jobs:
 
       - name: Setup Nix
         uses: ./.github/actions/setup-nix
-
-      - name: Install dependencies
-        run: nix develop --command just install ${{ matrix.sync-extras }}
+        with:
+          tools: uv ty just bun pnpm_10 typescript-go
 
       - name: Run Lint
-        run: nix develop --command just lint
+        run: just lint
 
       - name: Run Ty
-        run: nix develop --command just ty
+        run: just ty
 
       - name: Run Tests
-        run: nix develop --command just test
+        run: just test
 
   coverage:
     runs-on: ubuntu-latest
@@ -72,12 +69,11 @@ jobs:
 
       - name: Setup Nix
         uses: ./.github/actions/setup-nix
-
-      - name: Install dependencies
-        run: nix develop --command just install --all-extras
+        with:
+          tools: uv just bun pnpm_10 typescript-go
 
       - name: Run Tests with Coverage
-        run: nix develop --command just coverage
+        run: just coverage
 
       - name: Create Coverage Badge
         uses: jaywcjlove/coverage-badges-cli@4e8975aa2628e3329126e7eee36724d07ed86fda # v2.2.0

--- a/.github/workflows/nix-flake.yaml
+++ b/.github/workflows/nix-flake.yaml
@@ -26,8 +26,10 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
 
-      - name: Setup Nix
-        uses: ./.github/actions/setup-nix
+      - name: Install Nix
+        uses: cachix/install-nix-action@0b0e072294b088b73964f1d72dfdac0951439dbd # v31.8.4
+        with:
+          github_access_token: ${{ github.token }}
 
       - name: Check flake
-        run: nix flake check --all-systems --show-trace
+        run: nix flake check --all-systems --print-build-logs --show-trace


### PR DESCRIPTION
## Summary

Replace `nix develop --command` with `nix profile install --inputs-from .` for CI workflows to improve performance.

## What Changed

- Add `tools` input to setup-nix action for specifying required nixpkgs packages
- Add `skip-uv-sync` input to skip Python dependency installation when not needed
- Install only required tools per job (e.g., gitleaks job only needs gitleaks)
- Remove Cachix setup (no longer needed without devShell evaluation)
- Add submodule initialisation and MCP mock server dependency setup to action
- Update nix-flake.yaml to use install-nix-action directly

## Why

The previous approach evaluated the full devShell and ran shellHook on every CI job, which was unnecessarily slow. By using `nix profile install`, each job installs only the tools it needs without evaluating the entire development environment.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switched CI from “nix develop --command” to “nix profile install --inputs-from .” so each job installs only the tools it needs. This speeds up CI and removes devShell evaluation and shellHook overhead.

- **New Features**
  - Added tools input to setup-nix to install specific nixpkgs packages per job.
  - Added skip-uv-sync input to skip Python dependency setup when not needed.
  - Auto-initializes git submodules and installs MCP mock server deps when present.

- **Refactors**
  - CI jobs call tools directly (e.g., just, gitleaks) instead of nix develop.
  - Removed Cachix setup from the action.
  - nix-flake workflow uses install-nix-action and prints build logs.

<sup>Written for commit 4507b84c2f7ee19475006f163241191c0d031837. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

