### PR TITLE
chore(deps): group all Python minor/patch updates into single PR [ENG-11910]

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -16,21 +16,9 @@ updates:
       - dependencies
       - python
     groups:
-      dev-dependencies:
+      python-minor-patch:
         patterns:
-          - "pytest*"
-          - "ruff"
-          - "ty"
-          - "pre-commit"
-        update-types:
-          - minor
-          - patch
-      ai-frameworks:
-        patterns:
-          - "openai*"
-          - "langchain*"
-          - "crewai*"
-          - "mcp*"
+          - "*"
         update-types:
           - minor
           - patch


### PR DESCRIPTION
## Summary
- Consolidate `dev-dependencies` and `ai-frameworks` groups into a single `python-minor-patch` group
- Use wildcard pattern `*` to capture all Python packages
- Reduces PR noise by bundling all minor and patch updates together

## Test plan
- [ ] Verify next Dependabot run creates grouped PRs for Python minor/patch updates

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Consolidated Dependabot groups into a single python-minor-patch group to bundle all Python minor and patch updates into one PR. Uses a wildcard pattern to capture every Python package and reduce PR noise.

- **Dependencies**
  - Combined dev-dependencies and ai-frameworks into python-minor-patch with pattern "*" and update-types: minor, patch.

<sup>Written for commit bc3b46f6d3b9bd993aebb5d86a51f9ca93f71687. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

