### PR TITLE
fix(ci): skip mock server install in release workflow [ENG-11910]

### DIFF
--- a/.github/actions/setup-nix/action.yaml
+++ b/.github/actions/setup-nix/action.yaml
@@ -9,6 +9,10 @@ inputs:
     description: "Skip uv sync step (useful for jobs that do not need Python dependencies)"
     required: false
     default: "false"
+  skip-mock-server:
+    description: "Skip MCP mock server dependencies installation (useful for jobs that do not run tests)"
+    required: false
+    default: "false"
 runs:
   using: "composite"
   steps:
@@ -42,7 +46,7 @@ runs:
       run: uv sync --all-extras
 
     - name: Install MCP mock server dependencies
-      if: inputs.skip-uv-sync != 'true'
+      if: inputs.skip-uv-sync != 'true' && inputs.skip-mock-server != 'true'
       shell: bash
       run: |
         if [ -f vendor/stackone-ai-node/package.json ]; then

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -27,6 +27,8 @@ jobs:
       - name: Setup Nix
         if: ${{ steps.release.outputs.release_created }}
         uses: ./.github/actions/setup-nix
+        with:
+          skip-mock-server: "true"
 
       - name: Update version in __init__.py
         if: ${{ steps.release.outputs.release_created }}


### PR DESCRIPTION
## Summary
- Add `skip-mock-server` input to setup-nix action to skip MCP mock server dependencies installation
- Use `skip-mock-server: "true"` in release workflow since it doesn't run tests

## Problem
Release Please workflow failed because `pnpm` was not installed (only `uv ty just` are in the default tools), but the action tried to run `pnpm install` for the mock server.

## Test plan
- [ ] Merge this PR and verify Release Please workflow succeeds

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Release Please failures by skipping MCP mock server dependency install in release runs. Adds a skip-mock-server flag to setup-nix and enables it in the release workflow so releases don’t require pnpm (unblocking ENG-11910).

- **Bug Fixes**
  - Added skip-mock-server input to .github/actions/setup-nix and conditionally skip mock server install.
  - Set skip-mock-server: "true" in .github/workflows/release.yaml for the release job.

<sup>Written for commit 9fb786aa719561754302b5f33acf7b2140aa5eef. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

