### PR TITLE
fix(nix): replace deprecated nixfmt-rfc-style with nixfmt

### DIFF
--- a/.claude/rules/nix-workflow.md
+++ b/.claude/rules/nix-workflow.md
@@ -16,7 +16,7 @@ devShells.default = pkgs.mkShellNoCC {
     uv
     ty
     just
-    nixfmt-rfc-style
+    nixfmt
 
     # your new tool here
     new-tool

--- a/flake.nix
+++ b/flake.nix
@@ -39,7 +39,6 @@
             projectRootFile = "flake.nix";
             programs = {
               nixfmt.enable = true;
-              nixfmt.package = pkgs.nixfmt-rfc-style;
               ruff-check.enable = true;
               ruff-format.enable = true;
             };
@@ -94,7 +93,7 @@
               uv
               ty
               just
-              nixfmt-rfc-style
+              nixfmt
 
               # security
               gitleaks


### PR DESCRIPTION
## Summary
- Remove explicit `nixfmt.package = pkgs.nixfmt-rfc-style` override in treefmt config (now defaults to nixfmt)
- Replace `nixfmt-rfc-style` with `nixfmt` in devShells.default
- Update nix-workflow.md documentation to reflect the change

## Test plan
- [x] `nix flake check` passes without deprecation warning

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switched from nixfmt-rfc-style to nixfmt across the flake to remove deprecation warnings and standardize formatting. Removed the treefmt nixfmt.package override (now defaults to nixfmt), updated devShells, and refreshed nix-workflow docs.

<sup>Written for commit b4823cd2489ed5337db4b26db57af72b3e6eae8d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

