### PR TITLE
ci(release): simplify nix setup by using nix develop directly

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -28,7 +28,7 @@ jobs:
         if: ${{ steps.release.outputs.release_created }}
         uses: ./.github/actions/setup-nix
         with:
-          skip-mock-server: "true"
+          skip-uv-sync: "true"
 
       - name: Update version in __init__.py
         if: ${{ steps.release.outputs.release_created }}


### PR DESCRIPTION
## Summary
- Use install-nix-action directly instead of setup-nix composite action
- Remove skip-mock-server option (not needed with nix develop)
- Leverage the full devShell environment instead of manually installing individual tools

## Test plan
- [ ] Verify next release workflow runs successfully

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Simplified the release workflow to run tasks with nix develop while keeping the shared setup-nix composite action. This standardizes tooling and relies on the devShell for dependencies.

- **Refactors**
  - Kept the local setup-nix composite action; run commands via nix develop.
  - Replaced skip-mock-server with skip-uv-sync since the devShell covers dependency setup.

<sup>Written for commit f7e55ddffcf4e3febab48e6c1133c57520c9c223. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

