### PR TITLE
refactor(ci): remove unused skip-mock-server option from setup-nix

### DIFF
--- a/.github/actions/setup-nix/action.yaml
+++ b/.github/actions/setup-nix/action.yaml
@@ -9,10 +9,6 @@ inputs:
     description: "Skip uv sync step (useful for jobs that do not need Python dependencies)"
     required: false
     default: "false"
-  skip-mock-server:
-    description: "Skip MCP mock server dependencies installation (useful for jobs that do not run tests)"
-    required: false
-    default: "false"
 runs:
   using: "composite"
   steps:
@@ -46,7 +42,7 @@ runs:
       run: uv sync --all-extras
 
     - name: Install MCP mock server dependencies
-      if: inputs.skip-uv-sync != 'true' && inputs.skip-mock-server != 'true'
+      if: inputs.skip-uv-sync != 'true'
       shell: bash
       run: |
         if [ -f vendor/stackone-ai-node/package.json ]; then


### PR DESCRIPTION
## Summary
- Remove `skip-mock-server` input from setup-nix action
- This option was only used by the release workflow, which now uses nix develop directly (#115)

## Test plan
- [ ] CI passes (this is a no-op change as no workflow uses skip-mock-server anymore)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the unused skip-mock-server input from the setup-nix action and simplified the install step to only check skip-uv-sync. The release workflow now uses nix develop, so this cleans up CI and removes a misleading option.

<sup>Written for commit 80abfacfe248101761c275be19e1f015776eca5b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

