### PR TITLE
ci(release): include uv.lock in release-please updates

### DIFF
--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -8,7 +8,14 @@
   "include-v-in-tag": true,
   "packages": {
     ".": {
-      "package-name": "stackone-ai"
+      "package-name": "stackone-ai",
+      "extra-files": [
+        {
+          "type": "generic",
+          "path": "uv.lock",
+          "glob": false
+        }
+      ]
     }
   },
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json"

--- a/uv.lock
+++ b/uv.lock
@@ -3972,7 +3972,7 @@ wheels = [
 
 [[package]]
 name = "stackone-ai"
-version = "2.0.0"
+version = "2.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "bm25s" },


### PR DESCRIPTION
## Summary
- Add uv.lock to release-please extra-files configuration
- Update uv.lock to reflect current version (2.1.1)

This prevents version drift between the published package and the lockfile. Previously, uv.lock was not updated during releases, causing `uv sync` to show a diff after checking out the latest main branch.

## Test plan
- [ ] Next release PR should include uv.lock version update

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make release-please update uv.lock during releases to keep the lockfile in sync and avoid version drift. Updated uv.lock to 2.1.1 to match the package version.

- **Bug Fixes**
  - Added uv.lock to release-please extra-files via a generic updater.
  - Bumped lockfile package version to 2.1.1 to prevent uv sync diffs.

<sup>Written for commit 238a1524915081c262b2c0ca7ea8e9da1c76d067. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

