### PR TITLE
ci(release): update uv.lock via workflow instead of release-please

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,6 +19,33 @@ jobs:
           config-file: .release-please-config.json
           manifest-file: .release-please-manifest.json
 
+      # Update uv.lock when release PR is created/updated
+      - name: Checkout repository (for PR update)
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        if: ${{ steps.release.outputs.pr }}
+        with:
+          ref: ${{ fromJSON(steps.release.outputs.pr).headBranchName }}
+
+      - name: Setup Nix (for PR update)
+        if: ${{ steps.release.outputs.pr }}
+        uses: ./.github/actions/setup-nix
+        with:
+          skip-uv-sync: "true"
+
+      - name: Update uv.lock
+        if: ${{ steps.release.outputs.pr }}
+        run: |
+          nix develop --command uv lock
+          if git diff --quiet uv.lock; then
+            echo "uv.lock is already up to date"
+          else
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+            git add uv.lock
+            git commit -m "chore: update uv.lock"
+            git push
+          fi
+
       # Only release to PyPI when a new release is created
       - name: Checkout repository
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1

--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -8,14 +8,7 @@
   "include-v-in-tag": true,
   "packages": {
     ".": {
-      "package-name": "stackone-ai",
-      "extra-files": [
-        {
-          "type": "generic",
-          "path": "uv.lock",
-          "glob": false
-        }
-      ]
+      "package-name": "stackone-ai"
     }
   },
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json"


### PR DESCRIPTION
## Summary
- Remove `extra-files` config from release-please (generic updater doesn't work for uv.lock)
- Add workflow steps to update uv.lock when release PR is created/updated

The release-please generic updater cannot reliably identify the correct version line in uv.lock since many packages have version fields. Instead, the workflow now runs `uv lock` after release-please creates/updates the PR.

## Test plan
- [ ] Verify release PR includes uv.lock update commit

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Move uv.lock updates from release-please to the release workflow. The release job now checks out the PR branch, runs uv lock, and commits changes so the lockfile matches the bumped version.

- **Bug Fixes**
  - Removed uv.lock from release-please extra-files (generic updater is unreliable).
  - Added workflow steps to run uv lock on release PRs via Nix, then commit/push only if uv.lock changed.

<sup>Written for commit 3ca16282329d7e0e6d06c58a1cedddaba8b08a0a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

