### PR TITLE
docs: fix Python version requirement to 3.10+

### DIFF
--- a/.claude/rules/development-workflow.md
+++ b/.claude/rules/development-workflow.md
@@ -17,7 +17,7 @@ This rule provides code style guidelines and project conventions for the StackOn
 ## Type Annotations
 
 - Full type annotations required for all public APIs
-- Use Python 3.11+ typing features
+- Use Python 3.10+ typing features
 - Run `just ty` to verify type correctness
 - Strict ty configuration is enforced
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,7 +94,7 @@ toolset = StackOneToolSet(
 
 ### Type Safety
 
-- Full type annotations required (Python 3.11+)
+- Full type annotations required (Python 3.10+)
 - Strict ty configuration
 - Use generics for better IDE support
 
@@ -108,7 +108,7 @@ toolset = StackOneToolSet(
 
 1. **Dependencies**: See `package-installation` rule for uv dependency management
 2. **Pre-commit**: Hooks configured for ruff and ty - run on all commits
-3. **Python Version**: Requires Python >=3.11
+3. **Python Version**: Requires Python >=3.10
 4. **Error Handling**: Custom exceptions (`StackOneError`, `StackOneAPIError`)
 5. **File Uploads**: Binary parameters auto-detected from OpenAPI specs
 6. **Context Window**: Tool loading warns when loading all tools (large context)

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ StackOne AI provides a unified interface for accessing various SaaS tools throug
 
 ## Requirements
 
-- Python 3.11+
+- Python 3.10+
 
 ## Installation
 


### PR DESCRIPTION
## Summary
- Fix documentation to correctly state Python 3.10+ requirement
- Update README.md, CLAUDE.md, and development-workflow.md
- Aligns with `pyproject.toml` which specifies `requires-python = ">=3.10"`

## Test plan
- [x] Verify pyproject.toml states `>=3.10`
- [x] Verify all docs now consistently say 3.10+

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Corrected the Python version requirement to 3.10+ across docs to match pyproject.toml, avoiding confusion for Python 3.10 users.
Updated README.md, CLAUDE.md, and development-workflow to reflect 3.10+ typing features and version support.

<sup>Written for commit 0734c77c7e6e00675585b5c2d0a4c9252980276d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

