### PR TITLE
feat(skills): add just-commands skill with dynamic context injection

### DIFF
--- a/.claude/skills/just-commands/SKILL.md
+++ b/.claude/skills/just-commands/SKILL.md
@@ -1,0 +1,11 @@
+---
+name: just-commands
+description: Available just commands for this project. Use when you need to know what development commands are available.
+user-invocable: false
+---
+
+## Available just commands
+
+```
+!`just --list`
+```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,26 +21,15 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 | **uv-scripts**               | `scripts/**/*.py`   | Utility script standards with UV                   |
 | **examples-standards**       | `examples/**/*`     | Example requirements and organization              |
 
+## Available Skills
+
+| Skill             | Description                                  |
+| ----------------- | -------------------------------------------- |
+| **just-commands** | Available just commands (dynamically loaded) |
+
 ## Project Overview
 
-StackOne AI SDK is a Python library that provides a unified interface for accessing various SaaS tools through AI-friendly APIs. It acts as a bridge between AI applications and multiple SaaS platforms (HRIS, CRM, ATS, LMS, Marketing, etc.) with support for OpenAI, LangChain, CrewAI, and Model Context Protocol (MCP).
-
-## Essential Development Commands
-
-```bash
-# Setup and installation
-just install           # Install dependencies and pre-commit hooks
-
-# Code quality
-just lint             # Run ruff linting
-just lint-fix         # Auto-fix linting issues
-just ty               # Run type checking
-
-# Testing
-just test             # Run all tests
-just test-tools       # Run tool-specific tests
-just test-examples    # Run example tests
-```
+StackOne AI SDK is a Python library that provides a unified interface for accessing various SaaS tools through AI-friendly APIs with support for OpenAI, LangChain, CrewAI, and Model Context Protocol (MCP).
 
 ## Code Architecture
 


### PR DESCRIPTION
## Summary

Add a new skill that uses Claude Code's dynamic context injection feature (`!`command`` syntax) to embed `just --list` output at runtime, replacing the static command list in CLAUDE.md.

## What Changed

- Added `.claude/skills/just-commands/SKILL.md` with dynamic `just --list` injection
- Updated `CLAUDE.md` to reference the skill instead of hardcoding commands

## Why

The static command list in CLAUDE.md required manual updates whenever the justfile changed. Using dynamic context injection keeps commands in sync automatically and demonstrates a useful Claude Code feature.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a just-commands skill that injects the output of `just --list` at runtime, replacing the static command list in CLAUDE.md. This keeps commands in sync and removes manual updates.

- **New Features**
  - Added .claude/skills/just-commands/SKILL.md with dynamic injection using !`just --list`.
  - Updated CLAUDE.md to add an Available Skills table referencing the skill and remove the static command list.

<sup>Written for commit aa80fd483ee190be0fea1e7744b29b70778dba32. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

