### PR TITLE
refactor(nix): remove flakeModule in favour of direct lib usage

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -41,11 +41,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1767281941,
-        "narHash": "sha256-6MkqajPICgugsuZ92OMoQcgSHnD6sJHwk8AxvMcIgTE=",
+        "lastModified": 1769069492,
+        "narHash": "sha256-Efs3VUPelRduf3PpfPP2ovEB4CXT7vHf8W+xc49RL/U=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "f0927703b7b1c8d97511c4116eb9b4ec6645a0fa",
+        "rev": "a1ef738813b15cf8ec759bdff5761b027e3e1d23",
         "type": "github"
       },
       "original": {
@@ -151,11 +151,11 @@
         "nixpkgs": "nixpkgs_3"
       },
       "locked": {
-        "lastModified": 1768158989,
-        "narHash": "sha256-67vyT1+xClLldnumAzCTBvU0jLZ1YBcf4vANRWP3+Ak=",
+        "lastModified": 1769691507,
+        "narHash": "sha256-8aAYwyVzSSwIhP2glDhw/G0i5+wOrren3v6WmxkVonM=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "e96d59dff5c0d7fddb9d113ba108f03c3ef99eca",
+        "rev": "28b19c5844cc6e2257801d43f2772a4b4c050a1b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Summary
- Replace `git-hooks.flakeModule` and `treefmt-nix.flakeModule` imports with direct lib usage
- Use `treefmt-nix.lib.evalModule` and `git-hooks.lib.${system}.run` directly
- Add `formatter` output for `nix fmt` support

## Test plan
- [x] `nix flake check` passes
- [x] Pre-commit hooks still work (gitleaks, treefmt, ty)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactor Nix flake to remove git-hooks/treefmt flakeModule imports and use their libs directly. Adds a formatter output for nix fmt with no behavior change to formatting or hooks.

- **Refactors**
  - Use treefmt-nix.lib.evalModule and git-hooks.lib.${system}.run directly.
  - Expose formatter output and use the treefmt wrapper in hooks.
  - Switch devShell hook install to pre-commit-check.shellHook; keep gitleaks, treefmt, and ty.

- **Dependencies**
  - Update git-hooks.nix and treefmt-nix revisions in flake.lock.

<sup>Written for commit 17fc0488dabc87d2a9aa2130c3fa119b1cbe56e5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

