### PR TITLE
feat(nix): add flake checks for CI validation

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -80,6 +80,109 @@
         {
           formatter = treefmtEval.config.build.wrapper;
 
+          checks = {
+            formatting = treefmtEval.config.build.check ./.;
+
+            gitleaks =
+              pkgs.runCommand "check-gitleaks"
+                {
+                  nativeBuildInputs = [ pkgs.gitleaks ];
+                  src = pkgs.lib.fileset.toSource {
+                    root = ./.;
+                    fileset = pkgs.lib.fileset.gitTracked ./.;
+                  };
+                }
+                ''
+                  cd $src
+                  gitleaks detect --source . --config .gitleaks.toml --no-git
+                  touch $out
+                '';
+
+            uv-lock =
+              pkgs.runCommand "check-uv-lock"
+                {
+                  nativeBuildInputs = [
+                    pkgs.uv
+                    pkgs.cacert
+                  ];
+                  src = pkgs.lib.fileset.toSource {
+                    root = ./.;
+                    fileset = pkgs.lib.fileset.gitTracked ./.;
+                  };
+                  SSL_CERT_FILE = "${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt";
+                }
+                ''
+                  cd $src
+                  export HOME=$(mktemp -d)
+                  uv lock --check
+                  touch $out
+                '';
+
+            ty =
+              pkgs.runCommand "check-ty"
+                {
+                  nativeBuildInputs = [
+                    pkgs.ty
+                    pkgs.uv
+                    pkgs.python313
+                    pkgs.cacert
+                  ];
+                  src = pkgs.lib.fileset.toSource {
+                    root = ./.;
+                    fileset = pkgs.lib.fileset.gitTracked ./.;
+                  };
+                  SSL_CERT_FILE = "${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt";
+                }
+                ''
+                  cp -r $src/. ./workdir
+                  chmod -R u+w ./workdir
+                  cd ./workdir
+
+                  export HOME=$(mktemp -d)
+                  export UV_LINK_MODE=copy
+
+                  uv sync --all-extras --locked --python ${pkgs.python313}/bin/python3.13
+                  uv run ty check stackone_ai
+                  touch $out
+                '';
+
+            pytest =
+              pkgs.runCommand "check-pytest"
+                {
+                  nativeBuildInputs = [
+                    pkgs.uv
+                    pkgs.python313
+                    pkgs.bun
+                    pkgs.pnpm_10
+                    pkgs.typescript-go
+                    pkgs.git
+                    pkgs.cacert
+                  ];
+                  src = pkgs.lib.fileset.toSource {
+                    root = ./.;
+                    fileset = pkgs.lib.fileset.gitTracked ./.;
+                  };
+                  SSL_CERT_FILE = "${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt";
+                }
+                ''
+                  cp -r $src/. ./workdir
+                  chmod -R u+w ./workdir
+                  cd ./workdir
+
+                  export HOME=$(mktemp -d)
+                  export UV_LINK_MODE=copy
+
+                  # Initialize git submodules
+                  git init
+                  git submodule update --init --recursive || true
+
+                  # Install dependencies and run tests
+                  uv sync --all-extras --locked --python ${pkgs.python313}/bin/python3.13
+                  uv run pytest
+                  touch $out
+                '';
+          };
+
           devShells.default = pkgs.mkShellNoCC {
             buildInputs = with pkgs; [
               uv


### PR DESCRIPTION
## Summary

Consolidate all CI checks into `nix flake check` for unified local and CI validation.

## What Changed

Added 5 flake checks:
- **formatting**: treefmt check (nixfmt, ruff-check, ruff-format, oxfmt)
- **gitleaks**: secret detection with `--no-git` flag for pure evaluation
- **uv-lock**: verify lockfile is up to date (`uv lock --check`)
- **ty**: type checking with Python 3.13
- **pytest**: test suite execution with all extras

## Why

- Enables running all CI validations locally with a single command: `nix flake check`
- Ensures reproducible builds with `--locked` flag
- Pins Python to 3.13 for compatibility with dependencies (e.g., onnxruntime)

## Testing

```bash
nix flake check --print-build-logs
```

All 5 checks pass (189 tests passed, 20 skipped).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Consolidates CI validation into nix flake check, so the same checks run locally and in CI with one command. Adds unified checks for formatting, secrets, lockfile, type checking, and tests.

- **New Features**
  - Flake checks: formatting (treefmt: nixfmt, ruff-check, ruff-format, oxfmt), gitleaks (--no-git), uv-lock (uv lock --check), ty, pytest (all extras).
  - Uses --locked for reproducible builds and pins Python to 3.13 for dependency compatibility.

<sup>Written for commit e214da093fd76c8edb94577b7ac4ba57cc7226bd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

