### PR TITLE
refactor(nix): simplify oxfmt includes to wildcard pattern

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -67,18 +67,7 @@
             settings.formatter.oxfmt = {
               command = "${pkgs.oxfmt}/bin/oxfmt";
               options = [ "--no-error-on-unmatched-pattern" ];
-              includes = [
-                "*.md"
-                "*.yml"
-                "*.yaml"
-                "*.json"
-                "*.ts"
-                "*.tsx"
-                "*.js"
-                "*.jsx"
-                "*.html"
-                "*.css"
-              ];
+              includes = [ "*" ];
               excludes = [
                 "CHANGELOG.md"
               ];


### PR DESCRIPTION
Simplifies the oxfmt formatter configuration by replacing the explicit file extension list with a wildcard pattern. The `--no-error-on-unmatched-pattern` flag handles unsupported file types gracefully, making the explicit list unnecessary and easier to maintain.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Simplify oxfmt configuration by replacing the explicit file extension includes with a single wildcard. The --no-error-on-unmatched-pattern flag ignores unsupported files, reducing maintenance without changing formatting behavior; existing excludes like CHANGELOG.md remain.

<sup>Written for commit b4c216ce5062c38718f15e0b9ef95b39cf3e23c8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

