### PR TITLE
refactor(skills): use defaultLocalTargets from agent-skills-nix

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,7 +5,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 ## Rules and Skills Structure
 
 - **Rules** (`.claude/rules/`): Automatically loaded based on file paths. Source of truth for project conventions.
-- **Skills** (`.claude/skills/`): Managed by Nix via [agent-skills-nix](https://github.com/Kyure-A/agent-skills-nix). Skills are sourced from [StackOneHQ/skills](https://github.com/StackOneHQ/skills) and installed automatically when entering `nix develop`.
+- **Skills** (`.agents/skills/`, `.claude/skills/`): Managed by Nix via [agent-skills-nix](https://github.com/Kyure-A/agent-skills-nix). Skills are sourced from [StackOneHQ/skills](https://github.com/StackOneHQ/skills) and installed automatically when entering `nix develop`.
 - **Cursor rules** (`.cursor/rules/`): Symlinks to `.claude/rules/` for consistency.
 
 ## Available Skills

--- a/flake.lock
+++ b/flake.lock
@@ -8,11 +8,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1769944375,
-        "narHash": "sha256-TmTyQvFz8rNCwN8MQZGFtgFGdJANF6P6nbxVOjQvpME=",
+        "lastModified": 1770218103,
+        "narHash": "sha256-InxSZomi7ajBm+d5dN3Yah5mh7+pTb3iuI3U380sqQ8=",
         "owner": "Kyure-A",
         "repo": "agent-skills-nix",
-        "rev": "bb2fc09cd0152867bd548422e66f4738b081d719",
+        "rev": "2e53d1a4c0fe78d758b99f5df0f79d558498002e",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -101,20 +101,10 @@
 
           # Agent skills bundle and targets
           bundle = agentLib.mkBundle { inherit pkgs selection; };
-          localTargets = {
-            claude = {
-              dest = ".claude/skills";
-              structure = "symlink-tree";
-              enable = true;
-              systems = [ ];
-            };
-            agents = {
-              dest = ".agents/skills";
-              structure = "symlink-tree";
-              enable = true;
-              systems = [ ];
-            };
-          };
+          # Use symlink-tree instead of copy-tree for skills
+          localTargets = inputs.nixpkgs.lib.mapAttrs (
+            _: t: t // { structure = "symlink-tree"; }
+          ) agentLib.defaultLocalTargets;
         in
         {
           formatter = treefmtEval.config.build.wrapper;


### PR DESCRIPTION
## Summary

- Replace manual localTargets definition with agentLib.defaultLocalTargets
- Override only the structure to use symlink-tree instead of copy-tree  
- Update agent-skills-nix to latest version (2026-02-04)
- Skills now install to both .agents/skills and .claude/skills

## Test plan

- [x] Run `nix develop` and verify skills install to both directories
- [x] Verify skills are symlinked to nix store

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactor skills target configuration to use agentLib.defaultLocalTargets with symlink-tree, reducing custom Nix code. Skills now install to both .agents/skills and .claude/skills, with docs updated.

- **Refactors**
  - Replace manual localTargets with agentLib.defaultLocalTargets and override structure to "symlink-tree".
  - Update CLAUDE.md to reflect both skills directories.

- **Dependencies**
  - Bump agent-skills-nix to the latest revision (2026-02-04).

<sup>Written for commit 7971799f4e270cf1a91bde175f71c631c8fbed52. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

