### PR TITLE
chore(direnv): watch uv.lock for automatic environment reload

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,1 +1,2 @@
+watch_file uv.lock
 use flake


### PR DESCRIPTION
Adds `watch_file uv.lock` to `.envrc` so direnv automatically re-evaluates the environment when the lockfile changes. This keeps dependencies in sync without requiring manual `direnv reload`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added watch_file uv.lock to .envrc so direnv auto-reloads when the lockfile changes. Keeps dependencies in sync without manual direnv reload.

<sup>Written for commit 86f8d117a20603e5db2221a7b6e2226d143cfed3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->


 
 **PR Summary by Typo**
------------

#### Overview
This PR improves the development environment setup by configuring `direnv` to automatically reload the environment when the `uv.lock` file is modified. This ensures that the Python environment remains synchronized with dependency changes without manual intervention.

#### Key Changes
- Added a `watch_file uv.lock` directive to the `.envrc` configuration.

#### Work Breakdown

| Category    | Lines Changed |
|-------------|---------------|
| New Work    | 1 (100.0%)    |
| Total Changes | 1           |

#### Linked JIRA Issues
No issues found. 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/notification?tab=codeHealth">Notification settings</a>.</h6>