### PR TITLE
 fix(search): fall back to local search when semantic results don't match MCP tools

### DIFF
--- a/stackone_ai/toolset.py
+++ b/stackone_ai/toolset.py
@@ -933,8 +933,8 @@ class StackOneToolSet:
             matched_tools = [t for t in all_tools if t.name in seen_names]
             matched_tools.sort(key=lambda t: action_order.get(t.name, float("inf")))
 
-            # If semantic returned results but none matched MCP tools, fall back to local search
-            if len(all_results) > 0 and len(matched_tools) == 0:
+            # Auto mode: if semantic returned results but none matched MCP tools, fall back to local
+            if effective_search == "auto" and len(matched_tools) == 0:
                 logger.warning(
                     "Semantic search returned %d results but none matched MCP tools, "
                     "falling back to local search",

--- a/stackone_ai/toolset.py
+++ b/stackone_ai/toolset.py
@@ -933,6 +933,21 @@ class StackOneToolSet:
             matched_tools = [t for t in all_tools if t.name in seen_names]
             matched_tools.sort(key=lambda t: action_order.get(t.name, float("inf")))
 
+            # If semantic returned results but none matched MCP tools, fall back to local search
+            if len(all_results) > 0 and len(matched_tools) == 0:
+                logger.warning(
+                    "Semantic search returned %d results but none matched MCP tools, "
+                    "falling back to local search",
+                    len(all_results),
+                )
+                return self._local_search(
+                    query,
+                    all_tools,
+                    connector=connector,
+                    top_k=effective_top_k,
+                    min_similarity=effective_min_sim,
+                )
+
             return Tools(matched_tools)
 
         except SemanticSearchError as e:

--- a/tests/test_semantic_search.py
+++ b/tests/test_semantic_search.py
@@ -959,3 +959,81 @@ class TestSemanticSearchDeduplication:
         assert results[0].id == "breathehr_1.0.0_breathehr_list_employees_global"
         # Sorted by score descending
         assert results[0].similarity_score == 0.95
+
+
+class TestZeroMatchFallback:
+    """Tests for fallback when semantic results don't match MCP tools."""
+
+    @patch.object(SemanticSearchClient, "search")
+    @patch("stackone_ai.toolset._fetch_mcp_tools")
+    def test_auto_mode_falls_back_when_no_tools_match(
+        self,
+        mock_fetch: MagicMock,
+        mock_search: MagicMock,
+    ) -> None:
+        """Auto mode falls back to local search when semantic results don't match any MCP tools."""
+        from stackone_ai import StackOneToolSet
+        from stackone_ai.toolset import _McpToolDefinition
+
+        # Semantic returns results with IDs that won't match MCP tool names
+        mock_search.return_value = SemanticSearchResponse(
+            results=[
+                SemanticSearchResult(
+                    id="unknown_1.0.0_nonexistent_action_global",
+                    similarity_score=0.95,
+                ),
+            ],
+            total_count=1,
+            query="manage employees",
+        )
+
+        mock_fetch.return_value = [
+            _McpToolDefinition(
+                name="bamboohr_create_employee",
+                description="Creates a new employee in BambooHR",
+                input_schema={"type": "object", "properties": {}},
+            ),
+        ]
+
+        toolset = StackOneToolSet(api_key="test-key", search={"method": "auto"})
+        tools = toolset.search_tools("manage employees", top_k=5)
+
+        # Should fall back to local search and return results (not empty)
+        assert len(tools) > 0
+
+    @patch.object(SemanticSearchClient, "search")
+    @patch("stackone_ai.toolset._fetch_mcp_tools")
+    def test_semantic_mode_does_not_fall_back(
+        self,
+        mock_fetch: MagicMock,
+        mock_search: MagicMock,
+    ) -> None:
+        """Semantic mode returns empty results when no tools match, does not fall back."""
+        from stackone_ai import StackOneToolSet
+        from stackone_ai.toolset import _McpToolDefinition
+
+        # Semantic returns results with IDs that won't match MCP tool names
+        mock_search.return_value = SemanticSearchResponse(
+            results=[
+                SemanticSearchResult(
+                    id="unknown_1.0.0_nonexistent_action_global",
+                    similarity_score=0.95,
+                ),
+            ],
+            total_count=1,
+            query="manage employees",
+        )
+
+        mock_fetch.return_value = [
+            _McpToolDefinition(
+                name="bamboohr_create_employee",
+                description="Creates a new employee in BambooHR",
+                input_schema={"type": "object", "properties": {}},
+            ),
+        ]
+
+        toolset = StackOneToolSet(api_key="test-key", search={"method": "auto"})
+        tools = toolset.search_tools("manage employees", search="semantic", top_k=5)
+
+        # Semantic mode should return empty, not fall back
+        assert len(tools) == 0


### PR DESCRIPTION
## Summary
            
  When semantic search returns results but none match MCP tool names (e.g. due to composite ID format differences), the SDK now falls back to local BM25+TF-IDF search instead of returning empty results.                                                                          
                                                                 
 Previously, `searchTools()` in auto mode only fell back to local search when the semantic API call failed. Now it also falls back when   
  the API succeeds but the returned action IDs don't match any fetched tools.                                                              
                                                                             
  ## Test plan                                                                                                                             
                                                            
  - [ ] Existing tests pass
  - [ ] Auto mode returns local results when semantic matches are empty
  - [ ] Semantic mode still raises on failure (no fallback)            
  - [ ] Local mode unaffected                              
  - [ ] Happy path (semantic results match tools) unaffected 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fallback to local BM25+TF‑IDF search when semantic search returns results that don’t match any MCP tool names. Prevents empty results in auto mode and makes tool discovery more reliable.

- **Bug Fixes**
  - Auto mode now falls back to local search if semantic results contain zero matching tools.
  - Adds a warning log before falling back; uses the same `top_k` and similarity thresholds.
  - In `semantic` mode, no fallback: returns empty on no match and still raises on API failure; `local` mode unchanged.

<sup>Written for commit 53dc30a3c1636e7d0ef69b728dcc229cf993ea0b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

