### PR TITLE
feat: add configurable HTTP timeout for tool execution

### DIFF
--- a/stackone_ai/models.py
+++ b/stackone_ai/models.py
@@ -65,6 +65,7 @@ class ExecuteConfig(BaseModel):
     parameter_locations: dict[str, ParameterLocation] = Field(
         default_factory=dict, description="Maps parameter names to their location in the request"
     )
+    timeout: float = Field(default=30.0, description="HTTP request timeout in seconds")
 
 
 class ToolParameters(BaseModel):
@@ -249,7 +250,7 @@ class StackOneTool(BaseModel):
             if query_params:
                 request_kwargs["params"] = query_params
 
-            response = httpx.request(**request_kwargs)
+            response = httpx.request(**request_kwargs, timeout=self._execute_config.timeout)
             response_status = response.status_code
             response.raise_for_status()
 

--- a/stackone_ai/toolset.py
+++ b/stackone_ai/toolset.py
@@ -69,6 +69,9 @@ class ExecuteToolsConfig(TypedDict, total=False):
     account_ids: list[str]
     """Account IDs to scope tool discovery and execution."""
 
+    timeout: float
+    """HTTP request timeout in seconds for tool execution. Defaults to 30."""
+
 
 _SEARCH_DEFAULT: SearchConfig = {"method": "auto"}
 
@@ -415,6 +418,7 @@ class _StackOneRpcTool(StackOneTool):
         api_key: str,
         base_url: str,
         account_id: str | None,
+        timeout: float = 30.0,
     ) -> None:
         execute_config = ExecuteConfig(
             method="POST",
@@ -423,6 +427,7 @@ class _StackOneRpcTool(StackOneTool):
             headers={},
             body_type="json",
             parameter_locations=dict(_RPC_PARAMETER_LOCATIONS),
+            timeout=timeout,
         )
         super().__init__(
             description=description,
@@ -1185,6 +1190,9 @@ class StackOneToolSet:
             type=str(schema.get("type") or "object"),
             properties=self._normalize_schema_properties(schema),
         )
+        timeout = (
+            self._execute_config.get("timeout", 30.0) if self._execute_config else 30.0
+        )
         return _StackOneRpcTool(
             name=tool_def.name,
             description=tool_def.description or "",
@@ -1192,6 +1200,7 @@ class StackOneToolSet:
             api_key=self.api_key,
             base_url=self.base_url,
             account_id=account_id,
+            timeout=timeout,
         )
 
     def _normalize_schema_properties(self, schema: dict[str, Any]) -> dict[str, Any]:


### PR DESCRIPTION
## Summary
- `httpx.request()` in `StackOneTool.execute()` was called without a `timeout` parameter, defaulting to httpx's 5s. Slow providers (e.g. Workday, which regularly takes 10-15s) cause `ReadTimeout` errors.
- Adds a `timeout` field to `ExecuteConfig` (default 30s) and passes it to `httpx.request()`
- Adds `timeout` to `ExecuteToolsConfig` so users can configure it at the toolset level

## Usage
```python
toolset = StackOneToolSet(
    execute={"account_ids": ["..."], "timeout": 60},
)
```

## Test plan
- [x] All existing tests pass (40/40 in `test_models.py`)
- [x] Verified manually against Workday connector — calls that previously timed out at 5s now succeed at 15s with `timeout=60`
- [ ] Default of 30s is backwards-compatible (previously was httpx's 5s default, so this is strictly more generous)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a configurable HTTP timeout for tool execution to reduce ReadTimeouts with slow providers. Default is 30s and applied to all tool HTTP requests, overridable per toolset.

- **New Features**
  - Added `timeout` to `ExecuteConfig` (default 30s) and pass it to `httpx.request(...)`.
  - Exposed `timeout` in `ExecuteToolsConfig` so it can be set on init, e.g. `StackOneToolSet(execute={"account_ids": ["..."], "timeout": 60})`.

<sup>Written for commit a329c46489fff4e1dda9dee2d587f24633f1183b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

