### PR TITLE
 feat(search-optimization): cache tool catalog and parallelize per-account MCP fetches

### DIFF
--- a/examples/benchmark_search.py
+++ b/examples/benchmark_search.py
@@ -1,0 +1,131 @@
+"""Benchmark: measure SDK search latency with caching.
+
+Runs fetch_tools, local (BM25+TF-IDF) search, and semantic search N times,
+reports cold vs warm average latency and the speedup from caching.
+
+Prerequisites:
+    - STACKONE_API_KEY environment variable
+    - STACKONE_ACCOUNT_ID environment variable
+
+Run with:
+    uv run python examples/benchmark_search.py              # default 100 iterations
+    uv run python examples/benchmark_search.py -n 50        # fewer for a quick check
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+import time
+
+try:
+    from dotenv import load_dotenv
+
+    load_dotenv()
+except ModuleNotFoundError:
+    pass
+
+from stackone_ai import StackOneToolSet
+
+QUERIES = [
+    "list events",
+    "cancel a meeting",
+    "send a message",
+    "get current user",
+    "list employees",
+]
+
+
+def bench(fn, n: int) -> tuple[float, float, list[float]]:
+    """Run fn() n times. Return (cold, warm_avg, all_times)."""
+    times: list[float] = []
+    for _ in range(n):
+        t = time.perf_counter()
+        fn()
+        times.append(time.perf_counter() - t)
+
+    cold = times[0]
+    warm_times = times[1:]
+    warm_avg = sum(warm_times) / len(warm_times) if warm_times else cold
+    return cold, warm_avg, times
+
+
+def fmt_ms(seconds: float) -> str:
+    return f"{seconds * 1000:8.1f}ms"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Benchmark SDK search latency")
+    parser.add_argument("--iterations", "-n", type=int, default=100, help="iterations per benchmark (default 100)")
+    args = parser.parse_args()
+    n = args.iterations
+
+    api_key = os.getenv("STACKONE_API_KEY")
+    account_id = os.getenv("STACKONE_ACCOUNT_ID")
+
+    if not api_key:
+        print("Set STACKONE_API_KEY to run this benchmark.")
+        return 1
+    if not account_id:
+        print("Set STACKONE_ACCOUNT_ID to run this benchmark.")
+        return 1
+
+    print(f"Benchmarking with account {account_id[:8]}..., {n} iterations each\n")
+
+    ts = StackOneToolSet(
+        api_key=api_key,
+        account_id=account_id,
+        search={"method": "auto", "top_k": 5},
+    )
+
+    results: list[tuple[str, float, float, float]] = []
+    query_idx = 0
+
+    def next_query() -> str:
+        nonlocal query_idx
+        q = QUERIES[query_idx % len(QUERIES)]
+        query_idx += 1
+        return q
+
+    # --- 1. fetch_tools ---
+    print(f"[1/3] fetch_tools x{n} ...")
+    ts.clear_catalog_cache()
+    cold, warm_avg, _ = bench(lambda: ts.fetch_tools(), n)
+    speedup = cold / warm_avg if warm_avg > 0 else float("inf")
+    results.append(("fetch_tools", cold, warm_avg, speedup))
+    print(f"       cold={fmt_ms(cold)}  warm_avg={fmt_ms(warm_avg)}  speedup={speedup:.0f}x")
+
+    # --- 2. local search (BM25 + TF-IDF) ---
+    print(f"[2/3] search_tools (local) x{n} ...")
+    ts.clear_catalog_cache()
+    query_idx = 0
+    cold, warm_avg, _ = bench(lambda: ts.search_tools(next_query(), search="local"), n)
+    speedup = cold / warm_avg if warm_avg > 0 else float("inf")
+    results.append(("search (local/BM25)", cold, warm_avg, speedup))
+    print(f"       cold={fmt_ms(cold)}  warm_avg={fmt_ms(warm_avg)}  speedup={speedup:.0f}x")
+
+    # --- 3. semantic search (auto) ---
+    print(f"[3/3] search_tools (semantic/auto) x{n} ...")
+    ts.clear_catalog_cache()
+    query_idx = 0
+    cold, warm_avg, _ = bench(lambda: ts.search_tools(next_query(), search="auto"), n)
+    speedup = cold / warm_avg if warm_avg > 0 else float("inf")
+    results.append(("search (semantic)", cold, warm_avg, speedup))
+    print(f"       cold={fmt_ms(cold)}  warm_avg={fmt_ms(warm_avg)}  speedup={speedup:.0f}x")
+
+    # --- Summary ---
+    print("\n" + "=" * 65)
+    print(f"{'Benchmark':<22} {'Cold':>10} {'Warm (avg)':>10} {'Speedup':>10}")
+    print("-" * 65)
+    for name, c, w, s in results:
+        print(f"{name:<22} {fmt_ms(c):>10} {fmt_ms(w):>10} {s:>9.0f}x")
+    print("=" * 65)
+
+    print(f"\nWarm = average of {n - 1} calls after the first (cold) call.")
+    print("Speedup = cold / warm_avg — shows the benefit of caching.\n")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/examples/benchmark_search.py
+++ b/examples/benchmark_search.py
@@ -11,6 +11,7 @@ Run with:
     uv run python examples/benchmark_search.py              # default 100 iterations
     uv run python examples/benchmark_search.py -n 50        # fewer for a quick check
 """
+
 from __future__ import annotations
 
 import argparse
@@ -56,7 +57,9 @@ def fmt_ms(seconds: float) -> str:
 
 def main() -> int:
     parser = argparse.ArgumentParser(description="Benchmark SDK search latency")
-    parser.add_argument("--iterations", "-n", type=int, default=100, help="iterations per benchmark (default 100)")
+    parser.add_argument(
+        "--iterations", "-n", type=int, default=100, help="iterations per benchmark (default 100)"
+    )
     args = parser.parse_args()
     n = args.iterations
 

--- a/examples/test_examples.py
+++ b/examples/test_examples.py
@@ -34,6 +34,7 @@ OPTIONAL_DEPENDENCIES = {
     "semantic_search_example.py": ["mcp"],
     "mcp_server.py": ["mcp"],
     "workday_integration.py": ["openai", "mcp"],
+    "benchmark_search.py": ["mcp"],
 }
 
 

--- a/stackone_ai/toolset.py
+++ b/stackone_ai/toolset.py
@@ -170,7 +170,6 @@ class _ExecuteTool(StackOneTool):
     """LLM-callable tool that executes a StackOne tool by name."""
 
     _toolset: Any = PrivateAttr(default=None)
-    _cached_tools: Any = PrivateAttr(default=None)
 
     def execute(
         self, arguments: str | JsonDict | None = None, *, options: JsonDict | None = None
@@ -185,10 +184,8 @@ class _ExecuteTool(StackOneTool):
             parsed = _ExecuteInput(**raw_params)
             tool_name = parsed.tool_name
 
-            if self._cached_tools is None:
-                self._cached_tools = self._toolset.fetch_tools(account_ids=self._toolset._account_ids)
-
-            target = self._cached_tools.get_tool(parsed.tool_name)
+            tools = self._toolset.fetch_tools(account_ids=self._toolset._account_ids)
+            target = tools.get_tool(parsed.tool_name)
 
             if target is None:
                 return {
@@ -602,6 +599,8 @@ class StackOneToolSet:
         execute_timeout = execute.get("timeout") if execute else None
         self._timeout: float = timeout if timeout is not None else (execute_timeout or 60.0)
         self._tools_cache: Tools | None = None
+        self._catalog_cache: dict[tuple[Any, ...], Tools] = {}
+        self._tool_index_cache: tuple[int, Any] | None = None
 
     def set_accounts(self, account_ids: list[str]) -> StackOneToolSet:
         """Set account IDs for filtering tools
@@ -613,7 +612,17 @@ class StackOneToolSet:
             This toolset instance for chaining
         """
         self._account_ids = account_ids
+        self.clear_catalog_cache()
         return self
+
+    def clear_catalog_cache(self) -> None:
+        """Invalidate cached tool catalog and local search index.
+
+        Call when linked accounts change outside of ``set_accounts`` or when
+        you need to force a fresh fetch from the StackOne MCP endpoint.
+        """
+        self._catalog_cache.clear()
+        self._tool_index_cache = None
 
     def get_search_tool(self, *, search: SearchMode | None = None) -> SearchTool:
         """Get a callable search tool that returns Tools collections.
@@ -802,7 +811,10 @@ class StackOneToolSet:
         if not available_connectors:
             return Tools([])
 
-        index = ToolIndex(list(all_tools))
+        cache_key = id(all_tools)
+        if self._tool_index_cache is None or self._tool_index_cache[0] != cache_key:
+            self._tool_index_cache = (cache_key, ToolIndex(list(all_tools)))
+        index = self._tool_index_cache[1]
         results = index.search(
             query,
             limit=top_k if top_k is not None else 5,
@@ -1171,14 +1183,31 @@ class StackOneToolSet:
             else:
                 account_scope = [None]
 
-            endpoint = f"{self.base_url.rstrip('/')}/mcp"
-            all_tools: list[StackOneTool] = []
+            cache_key = (
+                tuple(sorted(account_scope, key=lambda a: (a is None, a))),
+                tuple(sorted(providers)) if providers else None,
+                tuple(sorted(actions)) if actions else None,
+            )
+            cached = self._catalog_cache.get(cache_key)
+            if cached is not None:
+                return cached
 
-            for account in account_scope:
+            endpoint = f"{self.base_url.rstrip('/')}/mcp"
+
+            def _fetch_for_account(account: str | None) -> list[StackOneTool]:
                 headers = self._build_mcp_headers(account)
                 catalog = _fetch_mcp_tools(endpoint, headers)
-                for tool_def in catalog:
-                    all_tools.append(self._create_rpc_tool(tool_def, account))
+                return [self._create_rpc_tool(tool_def, account) for tool_def in catalog]
+
+            all_tools: list[StackOneTool] = []
+            if len(account_scope) == 1:
+                all_tools.extend(_fetch_for_account(account_scope[0]))
+            else:
+                max_workers = min(len(account_scope), 10)
+                with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as pool:
+                    futures = [pool.submit(_fetch_for_account, acc) for acc in account_scope]
+                    for future in concurrent.futures.as_completed(futures):
+                        all_tools.extend(future.result())
 
             if providers:
                 all_tools = [tool for tool in all_tools if self._filter_by_provider(tool.name, providers)]
@@ -1186,7 +1215,9 @@ class StackOneToolSet:
             if actions:
                 all_tools = [tool for tool in all_tools if self._filter_by_action(tool.name, actions)]
 
-            return Tools(all_tools)
+            result = Tools(all_tools)
+            self._catalog_cache[cache_key] = result
+            return result
 
         except ToolsetError:
             raise

--- a/stackone_ai/toolset.py
+++ b/stackone_ai/toolset.py
@@ -1185,7 +1185,7 @@ class StackOneToolSet:
 
             cache_key = (
                 tuple(sorted(account_scope, key=lambda a: (a is None, a))),
-                tuple(sorted(providers)) if providers else None,
+                tuple(sorted(p.lower() for p in providers)) if providers else None,
                 tuple(sorted(actions)) if actions else None,
             )
             cached = self._catalog_cache.get(cache_key)
@@ -1206,7 +1206,7 @@ class StackOneToolSet:
                 max_workers = min(len(account_scope), 10)
                 with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as pool:
                     futures = [pool.submit(_fetch_for_account, acc) for acc in account_scope]
-                    for future in concurrent.futures.as_completed(futures):
+                    for future in futures:
                         all_tools.extend(future.result())
 
             if providers:

--- a/tests/test_agent_tools.py
+++ b/tests/test_agent_tools.py
@@ -268,7 +268,11 @@ class TestToolExecute:
 
         assert "error" in result
 
-    def test_caches_fetched_tools(self):
+    def test_delegates_catalog_lookup_to_toolset(self):
+        # _ExecuteTool no longer holds a local cache; the toolset's catalog
+        # cache (see StackOneToolSet._catalog_cache) is the single source of
+        # truth. Verify execute always defers to the toolset so it benefits
+        # from that shared cache.
         toolset = MagicMock()
         toolset.api_key = "test-key"
         toolset._account_ids = []
@@ -286,7 +290,8 @@ class TestToolExecute:
         execute.execute({"tool_name": "test_tool"})
         execute.execute({"tool_name": "test_tool"})
 
-        toolset.fetch_tools.assert_called_once()
+        assert toolset.fetch_tools.call_count == 2
+        toolset.fetch_tools.assert_called_with(account_ids=[])
 
     def test_passes_account_ids_from_toolset(self):
         toolset = MagicMock()

--- a/tests/test_fetch_tools.py
+++ b/tests/test_fetch_tools.py
@@ -440,3 +440,225 @@ class TestFetchMcpToolsInternal:
             assert result[1].name == "tool_2"
             assert result[1].input_schema == {}  # None should become empty dict
             assert mock_session.list_tools.call_count == 2
+
+
+class TestCatalogCache:
+    """Verify fetch_tools memoization on StackOneToolSet._catalog_cache."""
+
+    def test_repeat_calls_hit_cache(self, monkeypatch):
+        calls = {"count": 0}
+
+        def fake_fetch(_endpoint: str, _headers: dict[str, str]) -> list[_McpToolDefinition]:
+            calls["count"] += 1
+            return [_McpToolDefinition(name="t", description="d", input_schema={})]
+
+        monkeypatch.setattr("stackone_ai.toolset._fetch_mcp_tools", fake_fetch)
+
+        toolset = StackOneToolSet(api_key="test-key")
+        toolset.fetch_tools()
+        toolset.fetch_tools()
+        toolset.fetch_tools()
+
+        assert calls["count"] == 1
+
+    def test_different_accounts_separate_cache_entries(self, monkeypatch):
+        calls = {"count": 0}
+
+        def fake_fetch(_endpoint: str, headers: dict[str, str]) -> list[_McpToolDefinition]:
+            calls["count"] += 1
+            acc = headers.get("x-account-id", "none")
+            return [_McpToolDefinition(name=f"t_{acc}", description="d", input_schema={})]
+
+        monkeypatch.setattr("stackone_ai.toolset._fetch_mcp_tools", fake_fetch)
+
+        toolset = StackOneToolSet(api_key="test-key")
+        toolset.fetch_tools(account_ids=["a"])
+        toolset.fetch_tools(account_ids=["a"])
+        assert calls["count"] == 1
+
+        toolset.fetch_tools(account_ids=["b"])
+        assert calls["count"] == 2
+
+        toolset.fetch_tools(account_ids=["a"])
+        assert calls["count"] == 2
+
+    def test_provider_and_action_filters_participate_in_cache_key(self, monkeypatch):
+        calls = {"count": 0}
+
+        def fake_fetch(_endpoint: str, _headers: dict[str, str]) -> list[_McpToolDefinition]:
+            calls["count"] += 1
+            return [
+                _McpToolDefinition(name="prov_list_a", description="", input_schema={}),
+                _McpToolDefinition(name="other_get_b", description="", input_schema={}),
+            ]
+
+        monkeypatch.setattr("stackone_ai.toolset._fetch_mcp_tools", fake_fetch)
+
+        toolset = StackOneToolSet(api_key="test-key")
+        toolset.fetch_tools()
+        toolset.fetch_tools(providers=["prov"])
+        toolset.fetch_tools(providers=["prov"])
+        toolset.fetch_tools(actions=["*_list_*"])
+
+        assert calls["count"] == 3
+
+    def test_clear_catalog_cache_forces_refetch(self, monkeypatch):
+        calls = {"count": 0}
+
+        def fake_fetch(_endpoint: str, _headers: dict[str, str]) -> list[_McpToolDefinition]:
+            calls["count"] += 1
+            return []
+
+        monkeypatch.setattr("stackone_ai.toolset._fetch_mcp_tools", fake_fetch)
+
+        toolset = StackOneToolSet(api_key="test-key")
+        toolset.fetch_tools()
+        toolset.clear_catalog_cache()
+        toolset.fetch_tools()
+
+        assert calls["count"] == 2
+
+    def test_account_id_ordering_does_not_affect_cache_hits(self, monkeypatch):
+        calls = {"count": 0}
+
+        def fake_fetch(_endpoint: str, _headers: dict[str, str]) -> list[_McpToolDefinition]:
+            calls["count"] += 1
+            return [_McpToolDefinition(name="t", description="", input_schema={})]
+
+        monkeypatch.setattr("stackone_ai.toolset._fetch_mcp_tools", fake_fetch)
+
+        toolset = StackOneToolSet(api_key="test-key")
+        toolset.fetch_tools(account_ids=["a", "b"])
+        # Reordered account list should hit the cache — matches Node SDK behavior.
+        toolset.fetch_tools(account_ids=["b", "a"])
+
+        assert calls["count"] == 2  # one call per account, total = 2
+
+    def test_set_accounts_invalidates_cache(self, monkeypatch):
+        calls = {"count": 0}
+
+        def fake_fetch(_endpoint: str, headers: dict[str, str]) -> list[_McpToolDefinition]:
+            calls["count"] += 1
+            acc = headers.get("x-account-id", "none")
+            return [_McpToolDefinition(name=f"t_{acc}", description="", input_schema={})]
+
+        monkeypatch.setattr("stackone_ai.toolset._fetch_mcp_tools", fake_fetch)
+
+        toolset = StackOneToolSet(api_key="test-key")
+        toolset.set_accounts(["a"])
+        toolset.fetch_tools()
+        toolset.fetch_tools()
+        assert calls["count"] == 1
+
+        toolset.set_accounts(["b"])
+        toolset.fetch_tools()
+        assert calls["count"] == 2
+
+
+class TestParallelFetch:
+    """Verify per-account fetches run concurrently."""
+
+    def test_parallel_across_accounts_bounded_by_slowest(self, monkeypatch):
+        import time
+
+        per_call_delay = 0.15
+
+        def slow_fetch(_endpoint: str, _headers: dict[str, str]) -> list[_McpToolDefinition]:
+            time.sleep(per_call_delay)
+            return [_McpToolDefinition(name="t", description="", input_schema={})]
+
+        monkeypatch.setattr("stackone_ai.toolset._fetch_mcp_tools", slow_fetch)
+
+        toolset = StackOneToolSet(api_key="test-key")
+        account_ids = [f"acc-{i}" for i in range(5)]
+
+        start = time.perf_counter()
+        toolset.fetch_tools(account_ids=account_ids)
+        elapsed = time.perf_counter() - start
+
+        # Sequential would be 5 * 0.15 = 0.75s; parallel should finish in well
+        # under half that. Give generous headroom for CI jitter.
+        assert elapsed < 0.45, f"expected parallel fetch, took {elapsed:.2f}s"
+
+    def test_preserves_all_tools_regardless_of_completion_order(self, monkeypatch):
+        def fake_fetch(_endpoint: str, headers: dict[str, str]) -> list[_McpToolDefinition]:
+            acc = headers.get("x-account-id", "none")
+            return [_McpToolDefinition(name=f"tool_{acc}", description="", input_schema={})]
+
+        monkeypatch.setattr("stackone_ai.toolset._fetch_mcp_tools", fake_fetch)
+
+        toolset = StackOneToolSet(api_key="test-key")
+        tools = toolset.fetch_tools(account_ids=["a", "b", "c", "d"])
+        names = {t.name for t in tools.to_list()}
+        assert names == {"tool_a", "tool_b", "tool_c", "tool_d"}
+
+    def test_single_account_failure_propagates(self, monkeypatch):
+        from stackone_ai.toolset import ToolsetLoadError
+
+        def flaky_fetch(_endpoint: str, headers: dict[str, str]) -> list[_McpToolDefinition]:
+            acc = headers.get("x-account-id", "none")
+            if acc == "b":
+                raise RuntimeError("boom")
+            return [_McpToolDefinition(name=f"tool_{acc}", description="", input_schema={})]
+
+        monkeypatch.setattr("stackone_ai.toolset._fetch_mcp_tools", flaky_fetch)
+
+        toolset = StackOneToolSet(api_key="test-key")
+        with pytest.raises(ToolsetLoadError):
+            toolset.fetch_tools(account_ids=["a", "b"])
+
+
+class TestToolIndexCache:
+    """Verify local-search ToolIndex is reused across search calls."""
+
+    def test_tool_index_reused_when_tools_identity_unchanged(self, monkeypatch):
+        from stackone_ai import local_search as ls_module
+
+        def fake_fetch(_endpoint: str, _headers: dict[str, str]) -> list[_McpToolDefinition]:
+            return [
+                _McpToolDefinition(name="foo_list_bar", description="list bars", input_schema={}),
+                _McpToolDefinition(name="foo_get_baz", description="get baz", input_schema={}),
+            ]
+
+        monkeypatch.setattr("stackone_ai.toolset._fetch_mcp_tools", fake_fetch)
+
+        build_count = {"count": 0}
+        original_init = ls_module.ToolIndex.__init__
+
+        def counting_init(self, tools, hybrid_alpha=None):
+            build_count["count"] += 1
+            original_init(self, tools, hybrid_alpha)
+
+        monkeypatch.setattr(ls_module.ToolIndex, "__init__", counting_init)
+
+        toolset = StackOneToolSet(api_key="test-key", search={"method": "local"})
+        toolset.search_tools("bar")
+        toolset.search_tools("baz")
+
+        assert build_count["count"] == 1
+
+    def test_tool_index_rebuilt_after_clear_catalog_cache(self, monkeypatch):
+        from stackone_ai import local_search as ls_module
+
+        def fake_fetch(_endpoint: str, _headers: dict[str, str]) -> list[_McpToolDefinition]:
+            return [
+                _McpToolDefinition(name="foo_list_bar", description="list bars", input_schema={}),
+            ]
+
+        monkeypatch.setattr("stackone_ai.toolset._fetch_mcp_tools", fake_fetch)
+
+        build_count = {"count": 0}
+        original_init = ls_module.ToolIndex.__init__
+
+        def counting_init(self, tools, hybrid_alpha=None):
+            build_count["count"] += 1
+            original_init(self, tools, hybrid_alpha)
+
+        monkeypatch.setattr(ls_module.ToolIndex, "__init__", counting_init)
+
+        toolset = StackOneToolSet(api_key="test-key", search={"method": "local"})
+        toolset.search_tools("bar")
+        toolset.clear_catalog_cache()
+        toolset.search_tools("bar")
+
+        assert build_count["count"] == 2


### PR DESCRIPTION
## Problem

  `tool_search` latency in agent loops was ~3 seconds per call in setups with multiple linked accounts, while
  a direct hit to `/actions/search` via Postman returns in milliseconds. Investigation showed the SDK was
  doing the same catalog-fetch and index-build work on every single call:

  1. **`search_tools()` unconditionally called `fetch_tools()`** with no cache on the search path (the
  existing `_tools_cache` only covered the meta-tool execute path).
  2. **`fetch_tools()` opened a fresh MCP session per linked account sequentially** in a demo with 7
  accounts, that's 7 serial round-trips before any search logic ran.
  3. **`ToolIndex` (BM25 + TF-IDF over ~662 tools) was reconstructed on every local-search fallback call** 
  no caching.


## Fix

  Internal memoization only, no public API signature changes, no behavioral changes in the happy path.

  - **Catalog cache:** `StackOneToolSet._catalog_cache` memoizes `fetch_tools()` results keyed by
  `(sorted(account_scope), providers, actions)`. Shared across `search_tools`, `tool_execute`, `openai()`,
  `langchain()`, `search_action_names()` they all benefit transparently.
  - **Parallel per-account fetch:** replaced the sequential `for account in account_scope:` loop with a
  `ThreadPoolExecutor` fan-out (capped at 10 workers), mirroring the existing semantic-search parallelism
  pattern in the same file (`toolset.py:920-927`). Single-account path preserved as-is — no threading overhead
   for the common case.
  - **ToolIndex cache:** memoized on the toolset instance by `Tools` identity; rebuilt only when the
  underlying catalog changes.
  - **New public method:** `clear_catalog_cache()` for users rotating accounts mid-session.
  - **Invalidation:** `set_accounts()` now calls `clear_catalog_cache()` automatically.
  - **Dropped** redundant `_ExecuteTool._cached_tools` local cache  now delegates to the shared toolset
  cache.

## Expected latency change

  - Warm `tool_search`: ~3s → ~200ms (cache hit, roughly the latency of `/actions/search` alone).
  - Cold `tool_search` with N accounts: drops from ~N × per-account latency to ~max(per-account) + small
  overhead.
  - Subsequent `fetch_tools` / `openai()` / `langchain()` calls on the same toolset are near-instant.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cache the MCP tool catalog and local search index, and fetch per-account catalogs in parallel to cut `tool_search` latency in multi-account setups. Addresses ENG-12639.

- **Performance**
  - Catalog cache in `StackOneToolSet._catalog_cache` keyed by accounts/providers/actions (accounts order-insensitive; providers lowercased); used by `search_tools`, `tool_execute`, `openai()`, `langchain()`, `search_action_names()`.
  - Per-account MCP fetches run in parallel (up to 10 workers); single-account path stays non-threaded.
  - Local `ToolIndex` is cached by tools identity and rebuilt only when the catalog changes; invalidated via `clear_catalog_cache()`.
  - Added `clear_catalog_cache()`; `set_accounts()` now clears the cache and local index. `_ExecuteTool` always defers to `toolset.fetch_tools` to use the shared cache.
  - Latency: warm `tool_search` ~3s → ~200ms; cold calls across N accounts now bounded by the slowest account, not N.

- **New Features**
  - Added `examples/benchmark_search.py` to measure cold vs warm latency for `fetch_tools`, local search, and semantic search.

<sup>Written for commit 1c834b129f0c4484e776ed43ddfce0309a5b63be. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

