### PR TITLE
docs(readme): add Google ADK integration section 

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,49 @@ for tool_call in response.tool_calls:
 </details>
 
 <details>
+<summary>Google ADK Integration</summary>
+
+StackOne is a [first-party integration in Google's Agent Development Kit](https://adk.dev/integrations/stackone/), shipped as the `stackone-adk` plugin and compatible with [ADK 2.0](https://adk.dev/2.0/). The plugin implements ADK's `BasePlugin` interface and provides tool discovery, account auto-discovery, and lifecycle hooks.
+
+```bash
+uv add stackone-adk
+```
+
+```python
+import asyncio
+
+from google.adk.agents import Agent
+from google.adk.apps import App
+from google.adk.runners import InMemoryRunner
+from stackone_adk import StackOnePlugin
+
+
+async def main():
+    plugin = StackOnePlugin()
+    # Or scope to a specific account:
+    # plugin = StackOnePlugin(account_id="YOUR_ACCOUNT_ID")
+
+    agent = Agent(
+        model="gemini-flash-latest",
+        name="stackone_agent",
+        instruction="You are a helpful assistant powered by StackOne.",
+        tools=plugin.get_tools(),
+    )
+
+    app = App(name="stackone_app", root_agent=agent, plugins=[plugin])
+
+    async with InMemoryRunner(app=app) as runner:
+        await runner.run_debug("List the first 3 workers.", quiet=True)
+
+
+asyncio.run(main())
+```
+
+For configuration details and the `search_and_execute` mode, see the [stackone-adk repository](https://github.com/StackOneHQ/stackone-adk-plugin).
+
+</details>
+
+<details>
 <summary>Pydantic AI Integration</summary>
 
 StackOne tools convert to Pydantic AI `Tool` instances via `.to_pydantic_ai()`, parallel to `.to_openai()` and `.to_langchain()`:


### PR DESCRIPTION
 ## Summary      
  - Adds a collapsible Google ADK integration block to the Integration Examples
  section.                                                                     
  - Points users to the `stackone-adk` plugin, which is the first-party ADK        
  integration listed at https://adk.dev/integrations/stackone/ and compatible with
  ADK 2.0.                                                                         
  - Code matches the canonical example published on the ADK documentation site.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a collapsible Google ADK integration example to the README, showing how to use StackOne with ADK 2.0 via the `stackone-adk` plugin. Includes a runnable snippet and an install command.

- **New Features**
  - Collapsible section with an ADK 2.0 example using `stackone-adk`.
  - Adds `uv add stackone-adk` and a link to the plugin docs for configuration and `search_and_execute` mode.

<sup>Written for commit 534eccfddd7ab91c434db94580ece1442205f1ae. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

