### PR TITLE
fix(search): make ToolsetConfigError actionable and fix misleading docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,7 +228,10 @@ For the full catalog (or the meta search/execute tools), use the `.pydantic_ai()
 ```python
 toolset = StackOneToolSet()
 tools = toolset.pydantic_ai(account_ids=[os.environ["STACKONE_ACCOUNT_ID"]])
-# or pydantic_ai(mode="search_and_execute") for agent-driven discovery
+
+# For agent-driven discovery, enable search on the constructor:
+# toolset = StackOneToolSet(search={"method": "auto"})
+# tools = toolset.pydantic_ai(mode="search_and_execute")
 ```
 
 </details>
@@ -360,8 +363,8 @@ Search for tools using natural language queries. Works with both semantic (cloud
 ```python
 import os
 
-# Get a callable search tool
-toolset = StackOneToolSet()
+# Get a callable search tool — search must be enabled on the toolset
+toolset = StackOneToolSet(search={"method": "auto"})
 account_id = os.getenv("STACKONE_ACCOUNT_ID")
 all_tools = toolset.fetch_tools(account_ids=[account_id])
 search_tool = toolset.get_search_tool()
@@ -381,7 +384,9 @@ Discover tools using natural language instead of exact names. Queries like "onbo
 import os
 from stackone_ai import StackOneToolSet
 
-toolset = StackOneToolSet()
+# Search must be enabled on the constructor — pass `search={}` for defaults,
+# or set a backend / top_k explicitly.
+toolset = StackOneToolSet(search={"method": "auto"})
 
 # Search by intent — returns Tools collection ready for any framework
 account_id = os.getenv("STACKONE_ACCOUNT_ID")

--- a/README.md
+++ b/README.md
@@ -362,15 +362,15 @@ Search for tools using natural language queries. Works with both semantic (cloud
 
 ```python
 import os
+from stackone_ai import StackOneToolSet
 
 # Get a callable search tool — search must be enabled on the toolset
 toolset = StackOneToolSet(search={"method": "auto"})
 account_id = os.getenv("STACKONE_ACCOUNT_ID")
-all_tools = toolset.fetch_tools(account_ids=[account_id])
 search_tool = toolset.get_search_tool()
 
-# Search for relevant tools — returns a Tools collection
-tools = search_tool("manage employees", top_k=5)
+# Search for relevant tools — returns a Tools collection scoped to the account
+tools = search_tool("manage employees", top_k=5, account_ids=[account_id])
 
 # Execute a discovered tool directly
 tools[0](limit=10)

--- a/stackone_ai/toolset.py
+++ b/stackone_ai/toolset.py
@@ -652,7 +652,7 @@ class StackOneToolSet:
         if self._search_config is None:
             raise ToolsetConfigError(
                 "Search is disabled. Pass search={} (or search={'method': 'auto'}) to "
-                "StackOneToolSet(...) to enable. See README 'Search Tools' for options."
+                "StackOneToolSet(...) to enable. See README 'Search Tool' for options."
             )
 
         config: SearchConfig = {**self._search_config}
@@ -666,7 +666,7 @@ class StackOneToolSet:
         if self._search_config is None:
             raise ToolsetConfigError(
                 "Search is disabled. Pass search={} (or search={'method': 'auto'}) to "
-                "StackOneToolSet(...) to enable. See README 'Search Tools' for options."
+                "StackOneToolSet(...) to enable. See README 'Search Tool' for options."
             )
 
         if account_ids:
@@ -933,7 +933,7 @@ class StackOneToolSet:
         if self._search_config is None:
             raise ToolsetConfigError(
                 "Search is disabled. Pass search={} (or search={'method': 'auto'}) to "
-                "StackOneToolSet(...) to enable. See README 'Search Tools' for options."
+                "StackOneToolSet(...) to enable. See README 'Search Tool' for options."
             )
 
         # Merge constructor defaults with per-call overrides
@@ -1087,7 +1087,7 @@ class StackOneToolSet:
         if self._search_config is None:
             raise ToolsetConfigError(
                 "Search is disabled. Pass search={} (or search={'method': 'auto'}) to "
-                "StackOneToolSet(...) to enable. See README 'Search Tools' for options."
+                "StackOneToolSet(...) to enable. See README 'Search Tool' for options."
             )
 
         # Merge constructor defaults with per-call overrides

--- a/stackone_ai/toolset.py
+++ b/stackone_ai/toolset.py
@@ -645,13 +645,14 @@ class StackOneToolSet:
 
         Example::
 
-            toolset = StackOneToolSet()
+            toolset = StackOneToolSet(search={"method": "auto"})
             search_tool = toolset.get_search_tool()
             tools = search_tool("manage employee records", account_ids=["acc-123"])
         """
         if self._search_config is None:
             raise ToolsetConfigError(
-                "Search is disabled. Initialize StackOneToolSet with a search config to enable."
+                "Search is disabled. Pass search={} (or search={'method': 'auto'}) to "
+                "StackOneToolSet(...) to enable. See README 'Search Tools' for options."
             )
 
         config: SearchConfig = {**self._search_config}
@@ -664,7 +665,8 @@ class StackOneToolSet:
         """Build tool_search + tool_execute tools scoped to this toolset."""
         if self._search_config is None:
             raise ToolsetConfigError(
-                "Search is disabled. Initialize StackOneToolSet with a search config to enable."
+                "Search is disabled. Pass search={} (or search={'method': 'auto'}) to "
+                "StackOneToolSet(...) to enable. See README 'Search Tools' for options."
             )
 
         if account_ids:
@@ -713,8 +715,8 @@ class StackOneToolSet:
             toolset = StackOneToolSet()
             tools = toolset.openai()
 
-            # Meta tools for agent-driven discovery
-            toolset = StackOneToolSet()
+            # Meta tools for agent-driven discovery — search must be enabled
+            toolset = StackOneToolSet(search={"method": "auto"})
             tools = toolset.openai(mode="search_and_execute")
         """
         effective_account_ids = account_ids or (
@@ -783,7 +785,8 @@ class StackOneToolSet:
             tools = toolset.pydantic_ai()
             agent = Agent("openai:gpt-5.4", tools=tools)
 
-            # Meta tools for agent-driven discovery
+            # Meta tools for agent-driven discovery — search must be enabled
+            toolset = StackOneToolSet(search={"method": "auto"})
             tools = toolset.pydantic_ai(mode="search_and_execute")
         """
         effective_account_ids = account_ids or (
@@ -929,7 +932,8 @@ class StackOneToolSet:
         """
         if self._search_config is None:
             raise ToolsetConfigError(
-                "Search is disabled. Initialize StackOneToolSet with a search config to enable."
+                "Search is disabled. Pass search={} (or search={'method': 'auto'}) to "
+                "StackOneToolSet(...) to enable. See README 'Search Tools' for options."
             )
 
         # Merge constructor defaults with per-call overrides
@@ -1082,7 +1086,8 @@ class StackOneToolSet:
         """
         if self._search_config is None:
             raise ToolsetConfigError(
-                "Search is disabled. Initialize StackOneToolSet with search config to enable."
+                "Search is disabled. Pass search={} (or search={'method': 'auto'}) to "
+                "StackOneToolSet(...) to enable. See README 'Search Tools' for options."
             )
 
         # Merge constructor defaults with per-call overrides


### PR DESCRIPTION
## Summary
- Rewrite the `ToolsetConfigError` "Search is disabled" message at all 4 raise sites to show the exact constructor arg needed (`search={}` or `search={"method": "auto"}`)
- Fix 3 README snippets that called `StackOneToolSet()` with no args before invoking `pydantic_ai(mode="search_and_execute")`, `get_search_tool()`, or `search_tools()` — these would all raise `ToolsetConfigError` at runtime
- Fix `openai()`, `pydantic_ai()`, and `get_search_tool()` docstring examples that showed the same misleading pattern

No behavior change — default remains `search=None` (disabled).

## Test plan
- [ ] `just lint` passes
- [ ] `just ty` passes
- [ ] Run `examples/search_tools.py` against a sandbox account to confirm the working path is unaffected
- [ ] Manually trigger the error to verify the new message renders cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes the "Search is disabled" error actionable and points to the correct README section. Fixes examples so search-enabled usage works out of the box. No behavior change; search remains opt-in.

- **Bug Fixes**
  - Updated all four `ToolsetConfigError` sites to suggest `search={}` or `search={"method": "auto"}` and reference README "Search Tool".
  - Corrected README and docstring examples: construct `StackOneToolSet(search={"method": "auto"})` before using `pydantic_ai(mode="search_and_execute")`, `get_search_tool()`, or `search_tools()`; fixed Basic Usage snippet (added `StackOneToolSet` import, removed unused `fetch_tools`, and passed `account_ids` to the search call).

<sup>Written for commit 1b7a8c64c98fec8861b64b6f29bff84eb22a84e2. Summary will update on new commits. <a href="https://cubic.dev/pr/StackOneHQ/stackone-ai-python/pull/188?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

