### PR TITLE
feat(ENG-733): support flat_prefixed MCP param style

### DIFF
--- a/stackone_ai/toolset.py
+++ b/stackone_ai/toolset.py
@@ -7,6 +7,7 @@ import fnmatch
 import json
 import logging
 import os
+import re
 import threading
 from collections.abc import Coroutine, Sequence
 from dataclasses import dataclass
@@ -91,6 +92,14 @@ _RPC_PARAMETER_LOCATIONS = {
     "query": ParameterLocation.BODY,
 }
 _USER_AGENT = f"stackone-ai-python/{_SDK_VERSION}"
+
+# Param-style pinned on the /mcp tool-listing URL. The MCP schema and the RPC-execution unwrap
+# (_split_envelope_params) must agree on this, so it is pinned rather than following the server
+# default — the server default is free to change without breaking the SDK.
+_MCP_PARAM_STYLE = "flat_prefixed"
+
+# Matches a flat_prefixed envelope key: `<location>_<field>` (e.g. `path_id`, `query_limit`).
+_FLAT_ENVELOPE_KEY_PATTERN = re.compile(r"^(path|query|body|headers)_(.+)$")
 
 
 # --- Internal tool_search + tool_execute ---
@@ -444,24 +453,17 @@ class _StackOneRpcTool(StackOneTool):
     ) -> dict[str, Any]:
         parsed_arguments = self._parse_arguments(arguments)
 
-        body_payload = self._extract_record(parsed_arguments.pop("body", None))
-        headers_payload = self._extract_record(parsed_arguments.pop("headers", None))
-        path_payload = self._extract_record(parsed_arguments.pop("path", None))
-        query_payload = self._extract_record(parsed_arguments.pop("query", None))
-
-        rpc_body: dict[str, Any] = dict(body_payload or {})
-        for key, value in parsed_arguments.items():
-            rpc_body[key] = value
+        envelope = self._split_envelope_params(parsed_arguments)
 
         payload: dict[str, Any] = {
             "action": self.name,
-            "body": rpc_body,
-            "headers": self._build_action_headers(headers_payload),
+            "body": envelope["body"],
+            "headers": self._build_action_headers(envelope["headers"] or None),
         }
-        if path_payload:
-            payload["path"] = path_payload
-        if query_payload:
-            payload["query"] = query_payload
+        if envelope["path"]:
+            payload["path"] = envelope["path"]
+        if envelope["query"]:
+            payload["query"] = envelope["query"]
 
         return super().execute(payload, options=options)
 
@@ -477,10 +479,28 @@ class _StackOneRpcTool(StackOneTool):
         return dict(parsed)
 
     @staticmethod
-    def _extract_record(value: Any) -> dict[str, Any] | None:
-        if isinstance(value, dict):
-            return dict(value)
-        return None
+    def _split_envelope_params(params: dict[str, Any]) -> dict[str, dict[str, Any]]:
+        """Split LLM-supplied tool arguments into the RPC envelope (path/query/headers/body).
+
+        Tools are listed with ``?param-style=flat_prefixed``, so keys arrive as
+        ``<location>_<field>`` (for example ``path_id``, ``query_limit``). The prefix carries
+        the parameter location, so the split needs no per-action schema. A bare dict-valued
+        ``path``/``query``/``headers``/``body`` key is still bucketed for clients holding a
+        cached nested schema, and any other key falls through to the body.
+        """
+        buckets: dict[str, dict[str, Any]] = {"path": {}, "query": {}, "headers": {}, "body": {}}
+        for key, value in params.items():
+            match = _FLAT_ENVELOPE_KEY_PATTERN.match(key)
+            if match:
+                location, field = match.group(1), match.group(2)
+                buckets[location].setdefault(field, value)
+                continue
+            if key in ("path", "query", "headers", "body") and isinstance(value, dict):
+                for field, field_value in value.items():
+                    buckets[key].setdefault(field, field_value)
+                continue
+            buckets["body"][key] = value
+        return buckets
 
     def _build_action_headers(self, additional_headers: dict[str, Any] | None) -> dict[str, str]:
         headers: dict[str, str] = {}
@@ -1240,7 +1260,7 @@ class StackOneToolSet:
             if cached is not None:
                 return cached
 
-            endpoint = f"{self.base_url.rstrip('/')}/mcp"
+            endpoint = f"{self.base_url.rstrip('/')}/mcp?param-style={_MCP_PARAM_STYLE}"
 
             def _fetch_for_account(account: str | None) -> list[StackOneTool]:
                 headers = self._build_mcp_headers(account)

--- a/tests/test_fetch_tools.py
+++ b/tests/test_fetch_tools.py
@@ -679,4 +679,4 @@ class TestMcpParamStylePinning:
         toolset = StackOneToolSet(api_key="test-key", base_url="https://api.example.com")
         toolset.fetch_tools(account_ids=["acc1"])
 
-        assert "param-style=flat_prefixed" in captured["endpoint"]
+        assert captured["endpoint"] == "https://api.example.com/mcp?param-style=flat_prefixed"

--- a/tests/test_fetch_tools.py
+++ b/tests/test_fetch_tools.py
@@ -662,3 +662,21 @@ class TestToolIndexCache:
         toolset.search_tools("bar")
 
         assert build_count["count"] == 2
+
+
+class TestMcpParamStylePinning:
+    """The /mcp listing URL must pin param-style so the schema matches the RPC unwrap."""
+
+    def test_fetch_tools_pins_flat_prefixed_param_style(self, monkeypatch):
+        captured: dict[str, str] = {}
+
+        def fake_fetch(endpoint: str, headers: dict[str, str]) -> list[_McpToolDefinition]:
+            captured["endpoint"] = endpoint
+            return []
+
+        monkeypatch.setattr("stackone_ai.toolset._fetch_mcp_tools", fake_fetch)
+
+        toolset = StackOneToolSet(api_key="test-key", base_url="https://api.example.com")
+        toolset.fetch_tools(account_ids=["acc1"])
+
+        assert "param-style=flat_prefixed" in captured["endpoint"]

--- a/tests/test_tool_calling.py
+++ b/tests/test_tool_calling.py
@@ -327,16 +327,33 @@ class TestStackOneRpcTool:
         with pytest.raises(ValueError, match="Tool arguments must be a JSON object"):
             rpc_tool._parse_arguments("[1, 2, 3]")
 
-    def test_extract_record_with_dict(self, rpc_tool):
-        """Test _extract_record with dict input"""
-        result = rpc_tool._extract_record({"key": "value"})
-        assert result == {"key": "value"}
+    def test_split_envelope_params_routes_flat_prefixed_keys(self, rpc_tool):
+        """flat_prefixed keys are bucketed into the RPC envelope by their location prefix"""
+        actual = rpc_tool._split_envelope_params(
+            {
+                "path_id": "123",
+                "query_limit": 10,
+                "headers_x-custom": "value",
+                "body_name": "test",
+            }
+        )
+        assert actual["path"] == {"id": "123"}
+        assert actual["query"] == {"limit": 10}
+        assert actual["headers"] == {"x-custom": "value"}
+        assert actual["body"] == {"name": "test"}
 
-    def test_extract_record_with_non_dict(self, rpc_tool):
-        """Test _extract_record with non-dict input"""
-        assert rpc_tool._extract_record("string") is None
-        assert rpc_tool._extract_record(123) is None
-        assert rpc_tool._extract_record(None) is None
+    def test_split_envelope_params_buckets_nested_and_unprefixed_keys(self, rpc_tool):
+        """Bare nested envelopes are accepted and unprefixed keys fall through to the body"""
+        actual = rpc_tool._split_envelope_params(
+            {
+                "body": {"nested": "value"},
+                "path": {"id": "1"},
+                "extra": "x",
+            }
+        )
+        assert actual["path"] == {"id": "1"}
+        assert actual["query"] == {}
+        assert actual["body"] == {"nested": "value", "extra": "x"}
 
 
 class TestBinaryDownloadResponse:


### PR DESCRIPTION
## Problem

The SDK lists tools from `/mcp` without pinning a param-style, so the tool schema handed to the LLM follows the **server default**. Execution, however, goes through `/actions/rpc` with a hardcoded *nested* unwrap (`path`/`query`/`headers`/`body`). When the server default param-style flips `nested` → `flat_prefixed`, the LLM emits `path_id`/`query_limit`/… which the nested unwrap can't route: path and query params are dropped and the prefixed keys leak into the request body. The server-side MCP shim does not cover this — SDK execution bypasses the MCP transport and hits the actions RPC endpoint directly.

## Fix

- Pin `?param-style=flat_prefixed` on the `/mcp` tool-listing endpoint, so the schema the LLM sees is stable regardless of the server default.
- Replace the nested `_extract_record` unwrap with `_split_envelope_params`, which buckets `<location>_<field>` keys back into `path`/`query`/`headers`/`body`. The prefix carries the location, so no per-action schema is needed. Bare nested envelopes are still accepted (for clients holding a cached nested schema), and unprefixed keys fall through to the body.

Net effect: SDK tool calls use the higher-accuracy flat_prefixed schema and are immune to the server-side default flip.

## Tests

- `test_fetch_tools_pins_flat_prefixed_param_style`
- `test_routes_flat_prefixed_keys_by_location`
- `test_buckets_nested_envelope_and_unprefixed_keys`
- Backward-compat preserved: existing nested/unprefixed execution tests unchanged. `ty` type-check and `ruff` (lint + format) clean.

## Note

This protects SDK versions from this release forward. Already-published versions still break the moment the server default flips, so the server-side flip should be gated on quantifying old-version exposure by User-Agent.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Support the `flat_prefixed` MCP param style end-to-end so tool execution stays correct even if the server default changes. Addresses ENG-733 by pinning the `/mcp` schema and aligning RPC argument handling.

- **Bug Fixes**
  - Pin `/mcp?param-style=flat_prefixed` so tools expose `<location>_<field>` args consistently; tests assert the exact endpoint.
  - Replace the nested unwrap with `_split_envelope_params` to bucket `path_`/`query_`/`headers_`/`body_`-prefixed keys into the RPC envelope; still accepts nested dicts and treats unprefixed keys as body for backward compatibility.

<sup>Written for commit b895af103e02ffb575a2fbe90b3e4e090f691e3d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/StackOneHQ/stackone-ai-python/pull/192?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

