### PR TITLE
fix(deps): Avoid DOA-pin mcp below 2.0.0 ahead of upstream MCP v2 release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ packages = ["stackone_ai"]
 "stackone_ai/py.typed" = "stackone_ai/py.typed"
 
 [project.optional-dependencies]
-mcp = ["mcp>=1.3.0"]
+mcp = ["mcp>=1.3.0,<2.0.0"]
 pydantic-ai = ["pydantic-ai-slim>=1.83.0,<2.0.0"]
 examples = [
   "crewai>=0.102.0",

--- a/uv.lock
+++ b/uv.lock
@@ -4811,7 +4811,7 @@ requires-dist = [
     { name = "langchain-core", specifier = ">=0.1.0" },
     { name = "langchain-openai", marker = "extra == 'examples'", specifier = ">=1.1.14" },
     { name = "langgraph", marker = "extra == 'examples'", specifier = ">=1.1.6" },
-    { name = "mcp", marker = "extra == 'mcp'", specifier = ">=1.3.0" },
+    { name = "mcp", marker = "extra == 'mcp'", specifier = ">=1.3.0,<2.0.0" },
     { name = "numpy", specifier = ">=1.24.0" },
     { name = "openai", marker = "extra == 'examples'", specifier = ">=2.32.0" },
     { name = "pydantic", specifier = ">=2.10.6" },


### PR DESCRIPTION
## MCP v2

MCP Python SDK v2.0.0 ships[ 2026-07-28](https://blog.modelcontextprotocol.io/posts/2026-07-28-release-candidate/) alongside the new spec revision and is a breaking release. The `mcp` extra declared `mcp>=1.3.0` with no upper bound, so every fresh `pip install 'stackone-ai[mcp]'` would have resolved to 2.0.0 and broken `fetch_tools()` on day one:
Python SDK will be DOA once the v2 ships for every fresh install. 

## Lockfile 

`uv.lock` pinned 1.25.0, which protects CI and local development but **not consumers** a library's lockfile does not constrain downstream installs. The published constraint in `pyproject.toml` is what resolvers use.

## Potential Breaking Changes with mcp V2 

This change is to avoid DOA but there are few things might break that needs separate fix 

Verified against `mcp==2.0.0b1` locally. `_fetch_mcp_tools` (`stackone_ai/toolset.py`) has seven incompatibilities:

| Break | Detail |
|---|---|
| `mcp.types` removed | Types moved to a separate `mcp-types` distribution |
| `streamablehttp_client` | Renamed to `streamable_http_client` |
| `headers=` kwarg removed | Auth must move to a caller-supplied `httpx.AsyncClient` |
| Transport return shape | Yields a 2-tuple; the session-id getter is gone (sessions removed from the protocol) |
| `list_tools(cursor)` | Now keyword-only: `params=PaginatedRequestParams(cursor=...)` |
| `tool.inputSchema` | Renamed `tool.input_schema` |
| `result.nextCursor` | Renamed `result.next_cursor` |

The first two raise `ImportError`, which the existing handler converts to:

> `ToolsetConfigError: MCP dependencies are required for fetch_tools. Install with 'pip install "stackone-ai[mcp]"'.`

So affected users would be told to install a package they already have,  a misleading error on top of a hard failure.

Upstream explicitly recommends this bound for library maintainers ([SDK beta announcement](https://blog.modelcontextprotocol.io/posts/sdk-betas-2026-07-28/)).



## Notes

- The 19 fixture errors are caused by `vendor/stackone-ai-node/node_modules` being absent, so `tests/mocks/serve.ts` can't start. Tracked separately 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pin the `mcp` extra to `<2.0.0` to avoid breaking changes from the MCP Python SDK v2 and prevent fresh installs of `stackone-ai[mcp]` from failing. Updates `pyproject.toml` and `uv.lock` to enforce the bound until v2 support is added.

<sup>Written for commit ec5e9d9c0d21e88d2487032d5b428d3854b0c2b2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/StackOneHQ/stackone-ai-python/pull/194?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

