### PR TITLE
fix(deps): cap pydantic-ai in examples extra below 2.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ examples = [
   "langchain-openai>=1.1.14",
   "langgraph>=1.1.6",
   "openai>=2.32.0",
-  "pydantic-ai>=1.83.0",
+  "pydantic-ai>=1.83.0,<2.0.0",
   "python-dotenv>=1.0.1",
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -4815,7 +4815,7 @@ requires-dist = [
     { name = "numpy", specifier = ">=1.24.0" },
     { name = "openai", marker = "extra == 'examples'", specifier = ">=2.32.0" },
     { name = "pydantic", specifier = ">=2.10.6" },
-    { name = "pydantic-ai", marker = "extra == 'examples'", specifier = ">=1.83.0" },
+    { name = "pydantic-ai", marker = "extra == 'examples'", specifier = ">=1.83.0,<2.0.0" },
     { name = "pydantic-ai-slim", marker = "extra == 'pydantic-ai'", specifier = ">=1.83.0,<2.0.0" },
     { name = "python-dotenv", marker = "extra == 'examples'", specifier = ">=1.0.1" },
     { name = "typing-extensions", specifier = ">=4.0.0" },


### PR DESCRIPTION
## Summary

- Cap `pydantic-ai` in the `examples` optional-dependency group at `<2.0.0`, matching the existing `pydantic-ai-slim>=1.83.0,<2.0.0` cap on the `pydantic-ai` extra.
- Regenerate `uv.lock` to record the narrowed specifier. Resolution is unchanged (still pydantic-ai 1.83.0) — only the declared constraint moves. CI runs `uv sync --all-extras --locked`, which hard-fails on a lockfile whose constraints have drifted from `pyproject.toml`.
- Closes an inconsistency left from #194, which capped `mcp` at `<2.0.0` but left the `examples` extra unbounded against a breaking pydantic-ai v2.

## PR created for the release fix

#194 merged with a squash subject that had no conventional-commit type prefix, so release-please parsed zero releasable commits and never opened a release PR. This PR's `fix:` prefix restores the release train; the resulting 2.10.1 will also carry #194's `mcp<2.0.0` pin out to PyPI.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cap `pydantic-ai` in the `examples` extra to `<2.0.0` and update `uv.lock` to match. This aligns with the `pydantic-ai` extra, avoids v2 breakage, and keeps CI lockfile checks passing.

<sup>Written for commit 1a5a101db489508e52340691d6aee0f3ca9860ec. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/StackOneHQ/stackone-ai-python/pull/195?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

